### PR TITLE
Prevent module css conflicts

### DIFF
--- a/styles/tidy5e-sheet.css
+++ b/styles/tidy5e-sheet.css
@@ -2547,13 +2547,13 @@
     height: 380px;
 	}
 
-	.dnd5e.sheet.actor.character ul.skills-list li.skill {
+	.tidy5e.dnd5e.sheet.actor.character ul.skills-list li.skill {
 		border: none;
     flex: 0 0 21px;
     height: 21px;
 	}
 
-	.dnd5e.sheet.actor ul.skills-list li.skill .skill-proficiency {
+	.tidy5e.dnd5e.sheet.actor ul.skills-list li.skill .skill-proficiency {
     margin-right: 4px;
 	}
 


### PR DESCRIPTION
Two entries inside the media query were not prefixed with `.tidy5e`, leading them to affect all character sheets while the module is active.