### PR TITLE
Split Item Sheet into its own Sheet

### DIFF
--- a/module.json
+++ b/module.json
@@ -10,7 +10,8 @@
 	"esmodules": [
 		"./tidy5e-sheet.js",	
 		"./tidy5e-favorites.js",
-		"./tidy5e-npc.js"
+		"./tidy5e-npc.js",
+		"./tidy5e-item.js"	
 	],
 	"styles": [
 		"./fonts/signika-negative/signika-negative.css",

--- a/styles/darkmode/tidy5e-darkitems.css
+++ b/styles/darkmode/tidy5e-darkitems.css
@@ -16,7 +16,7 @@
 	box-shadow: 0 0 0 1px var(--darkmode-primary-accent) inset;
 }
 
-.dnd5e.sheet.item button {
+.tidy5e.dnd5e.sheet.item button {
 	color: var(--darkmode-primary-color);
 }
 

--- a/styles/tidy5e-items.css
+++ b/styles/tidy5e-items.css
@@ -4,47 +4,47 @@
 /* ------------------------- */
 
 
-.dnd5e.sheet a:hover {
+.tidy5e.dnd5e.sheet a:hover {
 	text-shadow: none;
 }
 
 /* Checkbox styling */
 
-.dnd5e.sheet.item input[type="checkbox"],
-.dnd5e.sheet.item button,
-.dnd5e.sheet.item select{
+.tidy5e.dnd5e.sheet.item input[type="checkbox"],
+.tidy5e.dnd5e.sheet.item button,
+.tidy5e.dnd5e.sheet.item select{
 	cursor: pointer;
 }
 
-.dnd5e.sheet.item button,
-.dnd5e.sheet.item select{
+.tidy5e.dnd5e.sheet.item button,
+.tidy5e.dnd5e.sheet.item select{
 	border: none;
 }
 
-.dnd5e.sheet.item input[type="text"] {
+.tidy5e.dnd5e.sheet.item input[type="text"] {
 	border: none;
 }
 
-.dnd5e.sheet.item input[type="text"]:hover,
-.dnd5e.sheet.item input[type="text"]:focus {
+.tidy5e.dnd5e.sheet.item input[type="text"]:hover,
+.tidy5e.dnd5e.sheet.item input[type="text"]:focus {
 	border: none;
 	box-shadow: 0 0 0 1px var(--default-primary-accent) inset;
 }
 
-.dnd5e.sheet.item input[type="checkbox"] {
+.tidy5e.dnd5e.sheet.item input[type="checkbox"] {
 	margin: 2px;
 }
 
-.dnd5e.sheet.item .window-content {
+.tidy5e.dnd5e.sheet.item .window-content {
 	padding: 0;
 }
 
-.dnd5e.sheet.item .sheet-header {
+.tidy5e.dnd5e.sheet.item .sheet-header {
 	padding: 1rem;
 	border: none; 
 }
 
-.dnd5e.sheet.item .sheet-header img.profile {
+.tidy5e.dnd5e.sheet.item .sheet-header img.profile {
 	flex: 0 0 80px;
 	width: 80px;
 	height: 80px;
@@ -52,24 +52,24 @@
 	margin-right: 0;
 }
 
-.dnd5e.sheet.item .sheet-header {
+.tidy5e.dnd5e.sheet.item .sheet-header {
 	flex: 0 0 80px;
 	padding: 1rem;
 	background: rgba(255,255,255,.2);
 }
 
-.dnd5e.sheet.item .sheet-header .header-details {
+.tidy5e.dnd5e.sheet.item .sheet-header .header-details {
 	margin-left: 1rem;
 	padding: .5rem 0;
 }
 
-.dnd5e.sheet.item .sheet-header h1.charname {
+.tidy5e.dnd5e.sheet.item .sheet-header h1.charname {
 	padding: 0;
 	height: 30px;
 	line-height: 18px;
 }
 
-.dnd5e.sheet.item .sheet-header h1 input {
+.tidy5e.dnd5e.sheet.item .sheet-header h1 input {
 	margin: 0;
 	padding: 0;
 	font-size: 24px;
@@ -77,7 +77,7 @@
 	width: 100%;
 }
 
-.dnd5e.sheet.item .sheet-header .item-subtitle {
+.tidy5e.dnd5e.sheet.item .sheet-header .item-subtitle {
 	padding: .25rem .5rem;
 	background: rgba(0,0,0,.1);
 	border-radius: 5px;
@@ -89,20 +89,20 @@
 	flex: 0 1 140px; 
 }
 
-.dnd5e.sheet.item .sheet-header .item-subtitle .item-type {
+.tidy5e.dnd5e.sheet.item .sheet-header .item-subtitle .item-type {
 	font-size: 20px;
 	line-height: 16px;
 	color: rgba(0,0,0,.7);
 }
 
-.dnd5e.sheet.item .sheet-header .item-subtitle .item-status {
+.tidy5e.dnd5e.sheet.item .sheet-header .item-subtitle .item-status {
 	font-size: 16px;
 	line-height: 14px;
 	margin-left: .25rem;
 	color: rgba(0,0,0,.4);
 }
 
-.dnd5e.sheet.item .sheet-header .summary {
+.tidy5e.dnd5e.sheet.item .sheet-header .summary {
 	border: 1px solid rgba(0,0,0,.2);
 	border-left: none;
 	border-right: none;
@@ -112,7 +112,7 @@
 	height: 28px;
 }
 
-.dnd5e.sheet.item .sheet-header .summary li {
+.tidy5e.dnd5e.sheet.item .sheet-header .summary li {
 	margin: 0;
 	padding: .25rem .5rem;
 	float: none;
@@ -123,27 +123,27 @@
 	height: 26px;
 }
 
-.dnd5e.sheet.item .sheet-header .summary li input {
+.tidy5e.dnd5e.sheet.item .sheet-header .summary li input {
 	height: 20px;
 }
 
-.dnd5e.sheet.item .sheet-header .summary li:first-child {
+.tidy5e.dnd5e.sheet.item .sheet-header .summary li:first-child {
 	border: none;
 	padding-left: 0;
 }
 
-.dnd5e.sheet.item .sheet-header .summary li:last-child {
+.tidy5e.dnd5e.sheet.item .sheet-header .summary li:last-child {
 	padding-right: 0;
 }
 
 /* navigation */
 
-.dnd5e.sheet.item .sheet-navigation {
+.tidy5e.dnd5e.sheet.item .sheet-navigation {
 	font-family: "Signika", sans-serif;
 	margin: 0;
 }
 
-.dnd5e.sheet.item .sheet-navigation .item {
+.tidy5e.dnd5e.sheet.item .sheet-navigation .item {
 	margin: 0;
 	padding: 5px 1rem 0 1rem;
 	background: rgba(255,255,255,.2);
@@ -155,7 +155,7 @@
 	height: 26px;
 }
 
-.dnd5e.sheet.item .sheet-navigation .item.active {
+.tidy5e.dnd5e.sheet.item .sheet-navigation .item.active {
 	background: transparent;
   box-shadow: 
   	-1px 0 0 0 rgba(0,0,0,.2),
@@ -167,16 +167,16 @@
 	text-shadow: none;
 }
 
-.dnd5e.sheet.item .sheet-navigation .item:hover {
+.tidy5e.dnd5e.sheet.item .sheet-navigation .item:hover {
 	color: var(--default-primary-accent);
 	text-shadow: none;
 }
 
-.dnd5e.sheet.item .sheet-navigation .item.active:hover {
+.tidy5e.dnd5e.sheet.item .sheet-navigation .item.active:hover {
 	color: inherit;
 }
 
-.dnd5e.sheet.item .sheet-navigation .item:first-child.active {
+.tidy5e.dnd5e.sheet.item .sheet-navigation .item:first-child.active {
   box-shadow: 
   	0 0 0 0 rgba(0,0,0,.2),
   	1px 0 0 0 rgba(0,0,0,.2),
@@ -184,7 +184,7 @@
   	0 0 0 0 rgba(0,0,0,.2);
 }
 
-.dnd5e.sheet.item .sheet-navigation .item:last-child.active {
+.tidy5e.dnd5e.sheet.item .sheet-navigation .item:last-child.active {
   box-shadow: 
   	-1px 0 0 0 rgba(0,0,0,.2),
   	0 0 0 0 rgba(0,0,0,.2),
@@ -194,48 +194,48 @@
 
 /* item properties */
 
-.dnd5e.sheet.item .sheet-body .item-properties .form-group {
+.tidy5e.dnd5e.sheet.item .sheet-body .item-properties .form-group {
 	border-bottom: 1px solid rgba(0,0,0,.1);
 }
 
-.dnd5e.sheet.item .sheet-body .item-properties .form-group:last-of-type {
+.tidy5e.dnd5e.sheet.item .sheet-body .item-properties .form-group:last-of-type {
 	border: none; 
 }
 
-.dnd5e.sheet.item .sheet-body .item-properties .form-group input {
+.tidy5e.dnd5e.sheet.item .sheet-body .item-properties .form-group input {
 	flex: 0 0 50px;
 }
 
-.dnd5e.sheet.item .sheet-body .item-properties .properties-list {
+.tidy5e.dnd5e.sheet.item .sheet-body .item-properties .properties-list {
 	margin-top: .25rem;
 }
 
-.dnd5e.sheet.item .sheet-body .item-properties .form-group + .properties-list {
+.tidy5e.dnd5e.sheet.item .sheet-body .item-properties .form-group + .properties-list {
 	margin-top: .5rem;
 }
 
 /* item sheet body */
 
-.dnd5e.sheet.item {
+.tidy5e.dnd5e.sheet.item {
 	min-height: 500px;
 }
 
-.dnd5e.sheet.item .sheet-body {
+.tidy5e.dnd5e.sheet.item .sheet-body {
 	padding: 1rem;
 	padding-right: .25rem;
 }
 
-.dnd5e.sheet.item .sheet-body .tab {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab {
 	padding: 0;
 }
 
-.dnd5e.sheet.item .sheet-body .item-properties {
+.tidy5e.dnd5e.sheet.item .sheet-body .item-properties {
 	margin: 0;    
 	padding: 0 .5rem 0 0;
   border-right: 1px solid rgba(0,0,0,.1);
 }
 
-.dnd5e.sheet.item .sheet-body .item-properties .properties-list li {
+.tidy5e.dnd5e.sheet.item .sheet-body .item-properties .properties-list li {
 	margin: 0 0 2px 0;
 	border: 1px solid rgba(0,0,0,.1);
 	border-radius: 5px;
@@ -245,11 +245,11 @@
 
 /* item sheet editor */
 
-.dnd5e.sheet.item .sheet-body .editor {
+.tidy5e.dnd5e.sheet.item .sheet-body .editor {
 	margin-left: .5rem;
 }
 
-.dnd5e.sheet.item .sheet-body .editor .editor-edit {
+.tidy5e.dnd5e.sheet.item .sheet-body .editor .editor-edit {
 	right: .75rem;
 	top: 0;
 	padding: 0;
@@ -258,7 +258,7 @@
 	background: transparent;
 }
 
-.dnd5e.sheet.item .sheet-body .editor .editor-edit i {
+.tidy5e.dnd5e.sheet.item .sheet-body .editor .editor-edit i {
 	font-size: 1em;
   position: absolute;
   top: 0;
@@ -267,12 +267,12 @@
   text-shadow: none;
 }
 
-.dnd5e.sheet.item .sheet-body .editor-content {
+.tidy5e.dnd5e.sheet.item .sheet-body .editor-content {
 	margin: 0;
 	padding: 0 .75rem 0 0;
 }
 
-.dnd5e.sheet.item .sheet-body .editor-content::before {
+.tidy5e.dnd5e.sheet.item .sheet-body .editor-content::before {
 	display: block;
 	content: 'Mechanics/Flavor Text';
 	font-weight: 600;
@@ -280,64 +280,64 @@
 	margin-bottom: .5rem
 }
 
-.dnd5e.sheet.item .sheet-body .tab.details {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details {
 	padding-right: .75rem;
 }
 
-.dnd5e.sheet.item .sheet-body .editor .tox .tox-toolbar__group {
+.tidy5e.dnd5e.sheet.item .sheet-body .editor .tox .tox-toolbar__group {
 	padding: 0;
 }
 
-.dnd5e.sheet.item .sheet-body .editor .tox .tox-tbtn {
+.tidy5e.dnd5e.sheet.item .sheet-body .editor .tox .tox-tbtn {
 	width: 24px;
 	height: 24px;
 }
 
-.dnd5e.sheet.item .sheet-body .editor .tox.tox-tinymce .tox-tbtn[title="Formats"] {
+.tidy5e.dnd5e.sheet.item .sheet-body .editor .tox.tox-tinymce .tox-tbtn[title="Formats"] {
 	width: 90px;
 }
 
-.dnd5e.sheet.item .sheet-body .editor .tox .tox-tbtn--select {
+.tidy5e.dnd5e.sheet.item .sheet-body .editor .tox .tox-tbtn--select {
 	width: auto;
 }
 
 /* details tab */
 
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-header,
-.dnd5e.sheet.item .sheet-body .tab.details .form-header {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-header,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-header {
 	border: none;
 	margin: 1rem .5rem .5rem .5rem;
 	padding: 0; 
 	font-size: 20px;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-header:first-child,
-.dnd5e.sheet.item .sheet-body .tab.details .form-header:first-child {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-header:first-child,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-header:first-child {
 	margin-top: 0;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group,
-.dnd5e.sheet.item .sheet-body .tab.dynamiceffects .form-group,
-.dnd5e.sheet.item .sheet-body .tab.magic-items .form-group,
-.dnd5e.sheet.item .sheet-body .tab.details .form-group {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.dynamiceffects .form-group,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.magic-items .form-group,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group {
 	margin: 2px 0;
 	padding: .25rem;
 	background: rgba(0,0,0, .075);
 	border-radius: 5px;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group.stacked,
-.dnd5e.sheet.item .sheet-body .tab.dynamiceffects .form-group.stacked,
-.dnd5e.sheet.item .sheet-body .tab.magic-items .form-group.stacked,
-.dnd5e.sheet.item .sheet-body .tab.details .form-group.stacked {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group.stacked,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.dynamiceffects .form-group.stacked,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.magic-items .form-group.stacked,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group.stacked {
 	display: flex;
 	flex-wrap: wrap;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group label.checkbox,
-.dnd5e.sheet.item .sheet-body .tab.dynamiceffects .form-group label.checkbox,
-.dnd5e.sheet.item .sheet-body .tab.magic-items .form-group label.checkbox,
-.dnd5e.sheet.item .sheet-body .tab.details .form-group label.checkbox {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group label.checkbox,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.dynamiceffects .form-group label.checkbox,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.magic-items .form-group label.checkbox,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group label.checkbox {
 	position: relative;
 	z-index: 1;
 	margin: 2px;
@@ -355,85 +355,85 @@
   flex: 0 0 calc(100% / 4 - 4px);
 }
 
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group label.checkbox {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group label.checkbox {
   flex: 0 0 calc(100% / 3 - 4px);
 }
 
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group label.checkbox:hover,
-.dnd5e.sheet.item .sheet-body .tab.dynamiceffects .form-group label.checkbox:hover,
-.dnd5e.sheet.item .sheet-body .tab.details .form-group label.checkbox:hover {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group label.checkbox:hover,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.dynamiceffects .form-group label.checkbox:hover,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group label.checkbox:hover {
 	background: rgba(0,100,0,.3);
 }
 
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group .checkbox:hover  input::after,
-.dnd5e.sheet.item .sheet-body .tab.dynamiceffects .form-group label.checkbox:hover  input::after,
-.dnd5e.sheet.item .sheet-body .tab.details .form-group .checkbox:hover input::after {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group .checkbox:hover  input::after,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.dynamiceffects .form-group label.checkbox:hover  input::after,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group .checkbox:hover input::after {
 	background: #b8b8b8;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.details .form-group input[name="data.activation.cost"],
-.dnd5e.sheet.item .sheet-body .tab.details .form-group input[name="data.target.value"],
-.dnd5e.sheet.item .sheet-body .tab.details .form-group input[name="data.range.value"],
-.dnd5e.sheet.item .sheet-body .tab.details .form-group input[name="data.duration.value"],
-.dnd5e.sheet.item .sheet-body .tab.details .form-group input[name="data.uses.value"],
-.dnd5e.sheet.item .sheet-body .tab.details .form-group input[name="data.damage.parts.0.0"] {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group input[name="data.activation.cost"],
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group input[name="data.target.value"],
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group input[name="data.range.value"],
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group input[name="data.duration.value"],
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group input[name="data.uses.value"],
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group input[name="data.damage.parts.0.0"] {
 	text-align: right
 }
 
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group input[type="text"]:hover,
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group select:hover,
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group button:hover,
-.dnd5e.sheet.item .sheet-body .tab.details .form-group input[type="text"]:hover,
-.dnd5e.sheet.item .sheet-body .tab.details .form-group select:hover,
-.dnd5e.sheet.item .sheet-body .tab.details .form-group button:hover,
-.dnd5e.sheet.item .sheet-body .tab.details .form-group select:focus {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group input[type="text"]:hover,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group select:hover,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group button:hover,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group input[type="text"]:hover,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group select:hover,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group button:hover,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group select:focus {
 	border: none; 
   box-shadow: 0 0 0 1px var(--default-primary-accent) inset;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.details .form-group label.prepared,
-.dnd5e.sheet.item .sheet-body .tab.details .form-group.recharge label{
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group label.prepared,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group.recharge label{
 	flex: unset !important;
 	padding-right: 8px;
 	margin: 0 .5rem 0 0;
 	flex-direction: row-reverse;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.details .form-group.recharge label{
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group.recharge label{
 	margin-right: 0;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.details .form-group label.prepared input,
-.dnd5e.sheet.item .sheet-body .tab.details .form-group.recharge label input {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group label.prepared input,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group.recharge label input {
 	width: 20px;
 	height: 20px;
 	top: initial;
 	margin: 0 4px 0 0;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.details .form-group input:disabled {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group input:disabled {
 	background: transparent;
 	color: rgba(0,0,0,.7);
 }
 
-.dnd5e.sheet.item .sheet-body .tab.details .form-group input[name="data.save.dc"] {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group input[name="data.save.dc"] {
 	text-align: center;
 	flex: 0 0 30px; 
 }
 
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group input:disabled:hover,
-.dnd5e.sheet.item .sheet-body .tab.details .form-group input:disabled:hover {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group input:disabled:hover,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group input:disabled:hover {
 	border: none !important;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group .checkbox input,
-.dnd5e.sheet.item .sheet-body .tab.details .form-group .checkbox input {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group .checkbox input,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group .checkbox input {
 	position: static;
 	margin: 0;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group .checkbox input::after,
-.dnd5e.sheet.item .sheet-body .tab.details .form-group .checkbox input::after {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group .checkbox input::after,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group .checkbox input::after {
 	content: '';
 	display: block;
 	position: absolute;
@@ -446,35 +446,35 @@
 	cursor: pointer;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group .checkbox input:checked::after,
-.dnd5e.sheet.item .sheet-body .tab.details .form-group .checkbox input:checked::after {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group .checkbox input:checked::after,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group .checkbox input:checked::after {
 	display: none;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group label,
-.dnd5e.sheet.item .sheet-body .tab.dynamiceffects .form-group label,
-.dnd5e.sheet.item .sheet-body .tab.details .form-group label {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group label,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.dynamiceffects .form-group label,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group label {
 	margin-left: .25rem;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group select,
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group input[type="text"],
-.dnd5e.sheet.item .sheet-body .tab.details .form-group select,
-.dnd5e.sheet.item .sheet-body .tab.details .form-group input[type="text"] {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group select,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group input[type="text"],
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group select,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group input[type="text"] {
 	background: rgba(255,255,255, .3);
 	border: none;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group input[type="text"]:hover,
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group select:hover,
-.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group button:hover,
-.dnd5e.sheet.item .sheet-body .tab.details .form-group input[type="text"]:hover,
-.dnd5e.sheet.item .sheet-body .tab.details .form-group select:hover,
-.dnd5e.sheet.item .sheet-body .tab.details .form-group button:hover {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group input[type="text"]:hover,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group select:hover,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.item-betterRolls .form-group button:hover,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group input[type="text"]:hover,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group select:hover,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.details .form-group button:hover {
 	background: rgba(255,255,255, .5);
 }
 
-.dnd5e.sheet.item .sheet-body input[type="checkbox"] {
+.tidy5e.dnd5e.sheet.item .sheet-body input[type="checkbox"] {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -488,48 +488,48 @@
   background-size: 60%;
 }
 
-.dnd5e.sheet.item .sheet-body label input[type="checkbox"] {
+.tidy5e.dnd5e.sheet.item .sheet-body label input[type="checkbox"] {
   border: none;
   box-shadow: none;
   position: relative;
 }
 
-.dnd5e.sheet.item .sheet-body input[type="checkbox"]:checked {
+.tidy5e.dnd5e.sheet.item .sheet-body input[type="checkbox"]:checked {
 	background-color: rgba(0,255,0,.3);
   background-image: url(../images/check-default-checked.svg);
 }
 
-.dnd5e.sheet.item .sheet-body label input[type="checkbox"]:checked {
+.tidy5e.dnd5e.sheet.item .sheet-body label input[type="checkbox"]:checked {
   background-color: transparent;
 }
 
-.dnd5e.sheet.item h4.damage-header {
+.tidy5e.dnd5e.sheet.item h4.damage-header {
 	margin: .5rem 0 0 .5rem;
 }
 
-.dnd5e.sheet.item .damage-control {
+.tidy5e.dnd5e.sheet.item .damage-control {
 	margin: 0 .5rem;
 	min-width: auto;
 	width: auto;
 	text-align: center;
 }
 
-.dnd5e.sheet.item .damage-header .damage-control {
+.tidy5e.dnd5e.sheet.item .damage-header .damage-control {
 
 }
 
-.dnd5e.sheet.item .damage-header .damage-control::after {
+.tidy5e.dnd5e.sheet.item .damage-header .damage-control::after {
 	display: inline-block;
 	content: 'Add Formula';
 	margin-left: .25rem;
   font-size: 12px;
 }
 
-.dnd5e.sheet.item .damage-parts li {
+.tidy5e.dnd5e.sheet.item .damage-parts li {
 	margin-top: 4px;
 }
 
-.dnd5e.sheet.item .damage-parts li:first-child {
+.tidy5e.dnd5e.sheet.item .damage-parts li:first-child {
 	margin-top: 0;
 }
 

--- a/styles/tidy5e-modules.css
+++ b/styles/tidy5e-modules.css
@@ -24,8 +24,8 @@
 	background: rgba(0,0,0,.6);
 }
 
-.dnd5e.sheet.item .item-betterRolls input[type="text"], 
-.dnd5e.sheet.item .item-betterRolls select {
+.tidy5e.dnd5e.sheet.item .item-betterRolls input[type="text"], 
+.tidy5e.dnd5e.sheet.item .item-betterRolls select {
 	height: 24px;
 	border: none;
 	background: rgba(255,255,255,.3); 
@@ -35,35 +35,35 @@
 /* Support Dynamic Effects  */
 /* ------------------------ */
 
-.dnd5e.sheet.item .sheet-body .tab.dynamiceffects {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.dynamiceffects {
 	padding: 0 .7rem 0 0;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.dynamiceffects > div {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.dynamiceffects > div {
 	float: left;
 	width: calc(50% - 2px);
 	flex-direction: row-reverse;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.dynamiceffects > div + div {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.dynamiceffects > div + div {
 	clear: none;
 	float: right;
 	width: calc(50% - 2px);
 	flex-direction: row-reverse;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.dynamiceffects > div label,
-.dnd5e.sheet.item .sheet-body .tab.dynamiceffects > div + div label {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.dynamiceffects > div label,
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.dynamiceffects > div + div label {
 	padding-top: 1px;
 	margin: 0;
 }
 
-.dnd5e.sheet.item .dynamiceffects-effect-list {
+.tidy5e.dnd5e.sheet.item .dynamiceffects-effect-list {
 	clear: both;
 	padding: 0;
 }
 
-.dnd5e.sheet.item .effect-header {
+.tidy5e.dnd5e.sheet.item .effect-header {
 	margin: 0 0 .25rem 0;
 	padding-top: .5rem;
 	line-height: 20px;
@@ -73,35 +73,35 @@
 	font-family: "Signika", sans-serif;
 }
 
-.dnd5e.sheet.item .effect-header:first-child,
-.dnd5e.sheet.item .dynamiceffects-effect-list .effect-name,
-.dnd5e.sheet.item .dynamiceffects-effect-list .effect-mode,
-.dnd5e.sheet.item .dynamiceffects-effect-list .effect-value,
-.dnd5e.sheet.item .dynamiceffects-effect-list .effect-header .effect-controls {
+.tidy5e.dnd5e.sheet.item .effect-header:first-child,
+.tidy5e.dnd5e.sheet.item .dynamiceffects-effect-list .effect-name,
+.tidy5e.dnd5e.sheet.item .dynamiceffects-effect-list .effect-mode,
+.tidy5e.dnd5e.sheet.item .dynamiceffects-effect-list .effect-value,
+.tidy5e.dnd5e.sheet.item .dynamiceffects-effect-list .effect-header .effect-controls {
 	border: none;
 }
 
-.dnd5e.sheet.item .dynamiceffects-effect-list .effect-header .effect-name {
+.tidy5e.dnd5e.sheet.item .dynamiceffects-effect-list .effect-header .effect-name {
 	flex: 1;
 	padding-top: 2px;
 	border: none;
 }
 
-.dnd5e.sheet.item .dynamiceffects-effect-list .effect-header .effect-mode,
-.dnd5e.sheet.item .dynamiceffects-effect-list .effect-header .effect-value {
+.tidy5e.dnd5e.sheet.item .dynamiceffects-effect-list .effect-header .effect-mode,
+.tidy5e.dnd5e.sheet.item .dynamiceffects-effect-list .effect-header .effect-value {
 	color: rgba(0,0,0,.4);
 	padding-top: 2px;
 	border: none;
 }
 
-.dnd5e.sheet.item .effect-header h3 {
+.tidy5e.dnd5e.sheet.item .effect-header h3 {
 	font-family: "Signika", sans-serif;
 	font-size: 13px;
 	margin: 0;
 	padding: 0;
 }
 
-.dnd5e.sheet.item .dynamiceffects-effect-list .effect {
+.tidy5e.dnd5e.sheet.item .dynamiceffects-effect-list .effect {
 	padding: 0;
   line-height: 30px;
   background: rgba(0,0,0,.1);
@@ -110,20 +110,20 @@
   margin: 2px 0;
 }
 
-.dnd5e.sheet.item .dynamiceffects-effect-list .effect .effect-name {
+.tidy5e.dnd5e.sheet.item .dynamiceffects-effect-list .effect .effect-name {
 	padding: 0 .5rem;
 	flex: 1;
 }
 
-.dnd5e.sheet.item .dynamiceffects-effect-list .effect-mode,
-.dnd5e.sheet.item .dynamiceffects-effect-list .effect-value {
+.tidy5e.dnd5e.sheet.item .dynamiceffects-effect-list .effect-mode,
+.tidy5e.dnd5e.sheet.item .dynamiceffects-effect-list .effect-value {
 	color: rgba(0,0,0,.6);
 	flex: 0 0 70px;
 	text-align: center;
 	border-left: 1px solid rgba(0,0,0,.15);
 }
 
-.dnd5e.sheet.item .dynamiceffects-effect-list .effect-controls {
+.tidy5e.dnd5e.sheet.item .dynamiceffects-effect-list .effect-controls {
 	flex: 0 0 66px;
 	text-align: center;
 	justify-content: center;
@@ -131,7 +131,7 @@
 	border-left: 1px solid rgba(0,0,0,.15);
 }
 
-.dnd5e.sheet.item .dynamiceffects-effect-list .effect-controls .effect-create {
+.tidy5e.dnd5e.sheet.item .dynamiceffects-effect-list .effect-controls .effect-create {
 	flex: 1;
 	text-align: center;
 	width: 100%;
@@ -144,14 +144,14 @@
 	padding-top: 2px;
 }
 
-.dnd5e.sheet.item .dynamiceffects-effect-list .effect-controls .effect-edit,
-.dnd5e.sheet.item .dynamiceffects-effect-list .effect-controls .effect-delete {
+.tidy5e.dnd5e.sheet.item .dynamiceffects-effect-list .effect-controls .effect-edit,
+.tidy5e.dnd5e.sheet.item .dynamiceffects-effect-list .effect-controls .effect-delete {
 	flex:0 0 22px;
 	text-align: center;
 	font-size: 12px;
 }
 
-.dnd5e.sheet.item .dynamiceffects-effect-list .effect-controls .effect-delete {
+.tidy5e.dnd5e.sheet.item .dynamiceffects-effect-list .effect-controls .effect-delete {
 	color: rgba(255,0,0,.5);
 }
 
@@ -163,16 +163,16 @@
 }
 
 
-.dnd5e.sheet.item .magic-items-content input[type="text"],
-.dnd5e.sheet.item .magic-items-content select {
+.tidy5e.dnd5e.sheet.item .magic-items-content input[type="text"],
+.tidy5e.dnd5e.sheet.item .magic-items-content select {
 	border: none !important;
 	background: rgba(255,255,255, .3);
 	color: var(--default-primary-color);
 }
 
-.dnd5e.sheet.item .magic-items-content input[type="text"]:hover,
-.dnd5e.sheet.item .magic-items-content select:hover,
-.dnd5e.sheet.item .magic-items-content select:focus {
+.tidy5e.dnd5e.sheet.item .magic-items-content input[type="text"]:hover,
+.tidy5e.dnd5e.sheet.item .magic-items-content select:hover,
+.tidy5e.dnd5e.sheet.item .magic-items-content select:focus {
 	border: none !important;
 	box-shadow: 0 0 0 1px var(--default-primary-accent);
 }
@@ -237,30 +237,30 @@
 
 /* Magic Item Sheet */
 
-.dnd5e.sheet.item .magic-items-content .magic-item-charges,
-.dnd5e.sheet.item .magic-items-content .magic-item-recharge input[type="text"] {
+.tidy5e.dnd5e.sheet.item .magic-items-content .magic-item-charges,
+.tidy5e.dnd5e.sheet.item .magic-items-content .magic-item-recharge input[type="text"] {
 	text-align: right;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.magic-items {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.magic-items {
 	padding: 0 .7rem 0 0;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.magic-items .input-select {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.magic-items .input-select {
 	height: 32px;
 	line-height: 30px;
 }
 
-.dnd5e.sheet.item .sheet-body .tab.magic-items .input-select label {
+.tidy5e.dnd5e.sheet.item .sheet-body .tab.magic-items .input-select label {
 	margin-left: 4px;
 }
 
-.dnd5e.sheet.item .magic-item-list {
+.tidy5e.dnd5e.sheet.item .magic-item-list {
 	clear: both;
 	padding: 0;
 }
 
-.dnd5e.sheet.item .magic-item-list .inventory-header {
+.tidy5e.dnd5e.sheet.item .magic-item-list .inventory-header {
 	margin: 0 0 .25rem 0;
 	padding-top: .5rem;
 	line-height: 20px;
@@ -270,45 +270,45 @@
 	font-family: "Signika", sans-serif;
 }
 
-.dnd5e.sheet.item .magic-item-list .inventory-header:first-child,
-.dnd5e.sheet.item .magic-item-list .inventory-header .item-name,
-.dnd5e.sheet.item .magic-item-list .inventory-header .spell-level-head,
-.dnd5e.sheet.item .magic-item-list .inventory-header .spell-consumption-head,
-.dnd5e.sheet.item .magic-item-list .inventory-header .spell-upcast-head,
-.dnd5e.sheet.item .magic-item-list .inventory-header .spell-cost-head,
-.dnd5e.sheet.item .magic-item-list .inventory-header .spell-constrols-head{
+.tidy5e.dnd5e.sheet.item .magic-item-list .inventory-header:first-child,
+.tidy5e.dnd5e.sheet.item .magic-item-list .inventory-header .item-name,
+.tidy5e.dnd5e.sheet.item .magic-item-list .inventory-header .spell-level-head,
+.tidy5e.dnd5e.sheet.item .magic-item-list .inventory-header .spell-consumption-head,
+.tidy5e.dnd5e.sheet.item .magic-item-list .inventory-header .spell-upcast-head,
+.tidy5e.dnd5e.sheet.item .magic-item-list .inventory-header .spell-cost-head,
+.tidy5e.dnd5e.sheet.item .magic-item-list .inventory-header .spell-constrols-head{
 	border: none;
 }
 
-.dnd5e.sheet.item .magic-item-list .item.inventory-header .item-name {
+.tidy5e.dnd5e.sheet.item .magic-item-list .item.inventory-header .item-name {
 	flex: 1;
 	padding: 2px 0 0 4px;
 	border: none;
 }
 
-.dnd5e.sheet.item .magic-item-list .inventory-header .spell-level-head,
-.dnd5e.sheet.item .magic-item-list .inventory-header .spell-consumption-head,
-.dnd5e.sheet.item .magic-item-list .inventory-header .spell-upcast-head,
-.dnd5e.sheet.item .magic-item-list .inventory-header .spell-cost-head,
-.dnd5e.sheet.item .magic-item-list .inventory-header .spell-controls-head {
+.tidy5e.dnd5e.sheet.item .magic-item-list .inventory-header .spell-level-head,
+.tidy5e.dnd5e.sheet.item .magic-item-list .inventory-header .spell-consumption-head,
+.tidy5e.dnd5e.sheet.item .magic-item-list .inventory-header .spell-upcast-head,
+.tidy5e.dnd5e.sheet.item .magic-item-list .inventory-header .spell-cost-head,
+.tidy5e.dnd5e.sheet.item .magic-item-list .inventory-header .spell-controls-head {
 	color: rgba(0,0,0,.4);
 	padding-top: 2px;
 	margin-right: 4px;
 	text-align: center;
 }
 
-.dnd5e.sheet.item .magic-item-list .inventory-header .spell-controls-head {
+.tidy5e.dnd5e.sheet.item .magic-item-list .inventory-header .spell-controls-head {
 	margin-right: 0;
 }
 
-.dnd5e.sheet.item .magic-item-list .inventory-header h3 {
+.tidy5e.dnd5e.sheet.item .magic-item-list .inventory-header h3 {
 	font-family: "Signika", sans-serif;
 	font-size: 13px;
 	margin: 0;
 	padding: 0;
 }
 
-.dnd5e.sheet.item .magic-item-list .item:not(.inventory-header) {
+.tidy5e.dnd5e.sheet.item .magic-item-list .item:not(.inventory-header) {
 	padding: 0;
   line-height: 30px;
   height: 30px;
@@ -319,60 +319,60 @@
   overflow: hidden; 
 }
 
-.dnd5e.sheet.item .magic-item-list .item .item-name {
+.tidy5e.dnd5e.sheet.item .magic-item-list .item .item-name {
 	padding: 0 .5rem 0 0;
 	flex: 1;
 }
 
-.dnd5e.sheet.item .magic-item-list .item.inventory-header .item-name {
+.tidy5e.dnd5e.sheet.item .magic-item-list .item.inventory-header .item-name {
 	cursor: default;
 }
 
-.dnd5e.sheet.item .magic-item-list .item .spell-level,
-.dnd5e.sheet.item .magic-item-list .item .spell-consumption,
-.dnd5e.sheet.item .magic-item-list .item .spell-upcast,
-.dnd5e.sheet.item .magic-item-list .item .spell-cost {
+.tidy5e.dnd5e.sheet.item .magic-item-list .item .spell-level,
+.tidy5e.dnd5e.sheet.item .magic-item-list .item .spell-consumption,
+.tidy5e.dnd5e.sheet.item .magic-item-list .item .spell-upcast,
+.tidy5e.dnd5e.sheet.item .magic-item-list .item .spell-cost {
 	color: rgba(0,0,0,.6);
 	text-align: center;
 	border-left: 1px solid rgba(0,0,0,.15);
 	margin: 3px 4px 3px 0;
 }
 
-.dnd5e.sheet.item .magic-item-list .inventory-header .spell-consumption-head,
-.dnd5e.sheet.item .magic-item-list .item .spell-consumption {
+.tidy5e.dnd5e.sheet.item .magic-item-list .inventory-header .spell-consumption-head,
+.tidy5e.dnd5e.sheet.item .magic-item-list .item .spell-consumption {
 	flex: 0 0 80px;
 }
 
-.dnd5e.sheet.item .magic-item-list .inventory-header .spell-cost-head,
-.dnd5e.sheet.item .magic-item-list .item .spell-cost {
+.tidy5e.dnd5e.sheet.item .magic-item-list .inventory-header .spell-cost-head,
+.tidy5e.dnd5e.sheet.item .magic-item-list .item .spell-cost {
 	flex: 0 0 50px;
 }
 
-.dnd5e.sheet.item .magic-item-list .inventory-header .spell-level-head,
-.dnd5e.sheet.item .magic-item-list .item .spell-level {
+.tidy5e.dnd5e.sheet.item .magic-item-list .inventory-header .spell-level-head,
+.tidy5e.dnd5e.sheet.item .magic-item-list .item .spell-level {
 	flex: 0 0 70px;
 }
 
-.dnd5e.sheet.item .magic-item-list .inventory-header .spell-upcast-head,
-.dnd5e.sheet.item .magic-item-list .item .spell-upcast {
+.tidy5e.dnd5e.sheet.item .magic-item-list .inventory-header .spell-upcast-head,
+.tidy5e.dnd5e.sheet.item .magic-item-list .item .spell-upcast {
 	flex: 0 0 85px;
 }
 
-.dnd5e.sheet.item .magic-item-list .item .feat-consumption {
+.tidy5e.dnd5e.sheet.item .magic-item-list .item .feat-consumption {
 	flex: 0 0 80px;
 	margin: 3px 4px 3px 0px;
 	text-align: center;
 }
 
-.dnd5e.sheet.item .magic-item-list .inventory-header .spell-controls-head,
-.dnd5e.sheet.item .magic-item-list .item-controls {
+.tidy5e.dnd5e.sheet.item .magic-item-list .inventory-header .spell-controls-head,
+.tidy5e.dnd5e.sheet.item .magic-item-list .item-controls {
 	flex: 0 0 30px;
 	text-align: center;
 	justify-content: center;
 	border: none;
 }
 
-.dnd5e.sheet.item .magic-item-list .item-controls a {
+.tidy5e.dnd5e.sheet.item .magic-item-list .item-controls a {
 	flex:0 0 22px;
 	text-align: center;
 	font-size: 12px;

--- a/tidy5e-item.js
+++ b/tidy5e-item.js
@@ -1,0 +1,12 @@
+import ItemSheet5e from "../../systems/dnd5e/module/item/sheet.js";
+
+export class Tidy5eItemSheet extends ItemSheet5e {
+	static get defaultOptions() {
+	  return mergeObject(super.defaultOptions, {
+			classes: ["tidy5e", "dnd5e", "sheet", "item"],
+		});
+	}
+}
+
+// Register Tidy5e Item Sheet and make default
+Items.registerSheet("dnd5e", Tidy5eItemSheet, {makeDefault: true});


### PR DESCRIPTION
Resolves #88 

Tidy Sheet has been modifying the styles of the default 5e Item sheet. This does not allow GMs to choose the default item sheet if they desire to without disabling the Tidy Sheet module itself.

It also opens up the door for a lot of inter-module conflicts. Instead we should register the Tidy 5e Item sheet as a different ItemSheet option, and set it to be the default when we do so.

Tested with Windows Client Foundry VTT 0.6.6.