### PR TITLE
support better rolls item sheet

### DIFF
--- a/tidy5e-item.js
+++ b/tidy5e-item.js
@@ -10,3 +10,9 @@ export class Tidy5eItemSheet extends ItemSheet5e {
 
 // Register Tidy5e Item Sheet and make default
 Items.registerSheet("dnd5e", Tidy5eItemSheet, {makeDefault: true});
+
+Hooks.once("ready", () => {
+  if (window.BetterRolls) {
+    window.BetterRolls.hooks.addItemSheet("Tidy5eItemSheet");
+	}
+});

--- a/tidy5e-item.js
+++ b/tidy5e-item.js
@@ -1,11 +1,11 @@
 import ItemSheet5e from "../../systems/dnd5e/module/item/sheet.js";
 
 export class Tidy5eItemSheet extends ItemSheet5e {
-	static get defaultOptions() {
-	  return mergeObject(super.defaultOptions, {
-			classes: ["tidy5e", "dnd5e", "sheet", "item"],
-		});
-	}
+  static get defaultOptions() {
+    return mergeObject(super.defaultOptions, {
+      classes: ["tidy5e", "dnd5e", "sheet", "item"],
+    });
+  }
 }
 
 // Register Tidy5e Item Sheet and make default
@@ -14,5 +14,5 @@ Items.registerSheet("dnd5e", Tidy5eItemSheet, {makeDefault: true});
 Hooks.once("ready", () => {
   if (window.BetterRolls) {
     window.BetterRolls.hooks.addItemSheet("Tidy5eItemSheet");
-	}
+  }
 });


### PR DESCRIPTION
Resolves #94 

- use the hooks in BetterRolls to register the Tidy 5e Item Sheet so that Better Rolls tab appears
- fix my previous usage of tabs instead of spaces on this file. It looks like spaces is the convention elsewhere (whoops, sorry)