### PR TITLE
bring master branch up to dnd5e 1.2.0

### DIFF
--- a/styles/tidy5e-sheet.css
+++ b/styles/tidy5e-sheet.css
@@ -1471,7 +1471,8 @@
 	content: none;
 }
 
-.tidy5e.sheet .traits .trait-selector {
+.tidy5e.sheet .traits .trait-selector,
+.tidy5e.sheet.actor .traits .config-button {
   flex: 0 0 10px;
   color: #999;
   margin-left: 4px;
@@ -1480,11 +1481,13 @@
 	padding: 2px 0 0 0;
 }
 
-.tidy5e.sheet.actor .traits:not(.expanded):not(.always-visible) .trait-selector {
+.tidy5e.sheet.actor .traits:not(.expanded):not(.always-visible) .trait-selector,
+.tidy5e.sheet.actor .traits:not(.expanded):not(.always-visible) .config-button {
 	display: none;
 }
 
 .tidy5e.sheet .traits .trait-selector:hover i.fas,
+.tidy5e.sheet .traits .config-button:hover i.fas,
 .tidy5e.sheet.actor .traits i.fas:hover {
 	color: var(--default-secondary-color);
 	text-shadow: none;

--- a/templates/actors/npc/parts/tidy5e-npc-traits.html
+++ b/templates/actors/npc/parts/tidy5e-npc-traits.html
@@ -1,9 +1,21 @@
 <div class="traits{{#if actor.flags.tidy5e-sheet.npcTraitsExpanded}} expanded{{/if}}">
-  <div class="form-group {{#unless data.traits.senses}}inactive {{/unless}}">
-    <article class="senses">
-      <div contenteditable="true" spellcheck="false" data-target="{{actor._id}}-senses" data-maxlength="100" data-placeholder="{{ localize 'DND5E.None' }}" data-label="{{localize 'DND5E.Senses'}}:">{{data.traits.senses}}</div>
-      <input data-input="{{actor._id}}-senses" type="hidden" name="data.traits.senses" value="{{data.traits.senses}}" placeholder="{{ localize 'DND5E.None' }}"/>
+  <div class="form-group {{#unless senses}}senses{{/unless}}  {{#if (and (eq data.traits.senses '') (tidy5e-isEmpty senses))}}inactive{{/if}}">
+    <article>
+      {{#if senses}}
+      <label for="senses">{{localize "DND5E.Senses"}}:</label>
+      {{#each senses as |v k|}}
+      <span class="tag {{k}}">{{v}}</span>
+      {{/each}}
+      {{else}}
+      <div contenteditable="true" data-target="{{actor._id}}-senses" spellcheck="false" data-placeholder="{{ localize 'DND5E.None' }}" data-label="{{localize 'DND5E.Senses'}}:">{{data.traits.senses}}</div>
+      <input type="hidden" data-input="{{actor._id}}-senses" name="data.traits.senses" value="{{data.traits.senses}}" placeholder="{{ localize 'DND5E.None' }}"/>
+      {{/if}}
     </article>
+    {{#if senses}}
+    <a class="config-button" data-action="senses" title="{{localize 'DND5E.SensesConfig'}}">
+      <i class="fas fa-pencil-alt"></i>
+    </a>
+    {{/if}}
   </div>
 
   <div class="form-group {{data.traits.languages.cssClass}}">

--- a/templates/actors/parts/tidy5e-inventory.html
+++ b/templates/actors/parts/tidy5e-inventory.html
@@ -32,7 +32,7 @@
 
   <ol class="item-list">
     {{#each section.items as |item iid|}}
-    <li class="item flexrow {{~#if item.data.attuned}} attuned {{/if}} {{~#if item.data.equipped}} equipped {{/if}}" data-item-id="{{item._id}}">
+    <li class="item flexrow {{~#if (or item.data.attuned (eq data.attunement 2))}} attuned {{/if}} {{~#if item.data.equipped}} equipped {{/if}}" data-item-id="{{item._id}}">
       <div class="item-name flexrow rollable" >
         <div class="item-image" style="background-image: url({{item.img}})">
           <i class="fa fa-dice-d20"></i>
@@ -49,7 +49,7 @@
       </div>
 
 
-      {{~#if item.data.attuned}} 
+      {{~#if (or item.data.attuned (eq data.attunement 2))}} 
       <div class="item-attuned" title="{{localize 'DND5E.Attuned'}}"><i class="fas fa-user-circle"></i></div>
       {{/if}}
 

--- a/templates/actors/parts/tidy5e-traits.html
+++ b/templates/actors/parts/tidy5e-traits.html
@@ -1,9 +1,21 @@
 <div class="traits{{#if actor.flags.tidy5e-sheet.traitsExpanded}} expanded{{/if}}">
-  <div class="form-group senses {{#unless data.traits.senses}}inactive{{/unless}}">
+  <div class="form-group {{#unless senses}}senses{{/unless}} {{#unless (or data.traits.senses (ne senses Object))}}inactive{{/unless}}">
     <article>
+      {{#if senses}}
+      <label for="senses">{{localize "DND5E.Senses"}}:</label>
+      {{#each senses as |v k|}}
+      <span class="tag {{k}}">{{v}}</span>
+      {{/each}}
+      {{else}}
       <div contenteditable="true" data-target="{{actor._id}}-senses" spellcheck="false" data-placeholder="{{ localize 'DND5E.None' }}" data-label="{{localize 'DND5E.Senses'}}:">{{data.traits.senses}}</div>
       <input type="hidden" data-input="{{actor._id}}-senses" name="data.traits.senses" value="{{data.traits.senses}}" placeholder="{{ localize 'DND5E.None' }}"/>
+      {{/if}}
     </article>
+    {{#if senses}}
+    <a class="config-button" data-action="senses" title="{{localize 'DND5E.SensesConfig'}}">
+      <i class="fas fa-pencil-alt"></i>
+    </a>
+    {{/if}}
   </div>
 
   <div class="form-group {{data.traits.languages.cssClass}}">

--- a/templates/actors/parts/tidy5e-traits.html
+++ b/templates/actors/parts/tidy5e-traits.html
@@ -1,5 +1,5 @@
 <div class="traits{{#if actor.flags.tidy5e-sheet.traitsExpanded}} expanded{{/if}}">
-  <div class="form-group {{#unless senses}}senses{{/unless}} {{#unless (or data.traits.senses (ne senses Object))}}inactive{{/unless}}">
+  <div class="form-group {{#unless senses}}senses{{/unless}} {{#if (and (eq data.traits.senses '') (tidy5e-isEmpty senses))}}inactive{{/if}}">
     <article>
       {{#if senses}}
       <label for="senses">{{localize "DND5E.Senses"}}:</label>

--- a/tidy5e-sheet.js
+++ b/tidy5e-sheet.js
@@ -12,6 +12,21 @@ Handlebars.registerHelper('ifEquals', function(arg1, arg2, options) {
     return (arg1 == arg2) ? options.fn(this) : options.inverse(this);
 });
 
+
+// handlebar helper to see if an object, array, or set is empty
+Handlebars.registerHelper('tidy5e-isEmpty', (input) => {
+  if (!input) {
+    return true;
+  }
+  if (input instanceof Array) {
+    return input.length < 1;
+  }
+  if (input instanceof Set) {
+    return input.size < 1;
+  }
+  return isObjectEmpty(input);
+});
+
 export class Tidy5eSheet extends ActorSheet5eCharacter {
 	
 	get template() {


### PR DESCRIPTION
These changes are backwards compatible with dnd5e 1.1.0.

- Swaps Senses out for something leveraging the default picker on both NPC and PC sheets.
![image](https://user-images.githubusercontent.com/7644614/101909444-7e46e380-3b8b-11eb-8b9f-cfc2bbd852c9.png)


- Fix Attunement class and icon appearance. `item.data.attuned` was removed for `item.data.attunement` which is 1, 2, or 3 where `3 === attuned`.
![image](https://user-images.githubusercontent.com/7644614/101909619-bcdc9e00-3b8b-11eb-91c1-fc03ce91f89c.png)

I looked at the Item Sheet, and since all tidy is doing is css changes that has no changes needed.
![image](https://user-images.githubusercontent.com/7644614/101909709-e269a780-3b8b-11eb-90af-54d21f85f87c.png)
