### PR TITLE
add release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,39 @@
+name: Release Creation
+
+on: 
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # Substitute the Manifest and Download URLs in the module.json
+    - name: Substitute Manifest and Download Links For Versioned Ones
+      id: sub_manifest_link_version
+      uses: microsoft/variable-substitution@v1
+      with:
+        files: 'module.json'
+      env:
+        version: ${{github.event.release.tag_name}}
+        manifest: https://github.com/${{github.repository}}/releases/latest/download/module.json
+        download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip
+
+    # Create a zip file with all files required by the module to add to the release
+    - run: zip -r ./module.zip module.json css/ fonts/ scripts/ images/ templates/ lang/
+
+    # Create a release for this specific version
+    - name: Update Release with Files
+      id: create_version_release
+      uses: ncipollo/release-action@v1
+      with:
+        allowUpdates: true # Set this to false if you want to prevent updating existing releases
+        name: ${{ github.event.release.name }}
+        draft: false
+        prerelease: false
+        token: ${{ secrets.GITHUB_TOKEN }}
+        artifacts: './module.json, ./module.zip'
+        tag: ${{ github.event.release.tag_name }}
+        body: ${{ github.event.release.body }}


### PR DESCRIPTION
Source: [League of FoundryVTT Developers module template](https://github.com/League-of-Foundry-Developers/FoundryVTT-Module-Template). There is a guide with pictures on that readme for how to use this.

Inspiration: [Package Releases and Version History](https://foundryvtt.wiki/en/development/guides/releases-and-history).

This PR will add a Github Action workflow that will only run when you create a release on the GH UI. The action will replace your module.json's `manifest` and `download` urls with the correct values based on the tag input, and then zip up the module files and attach them to the release.

This enables people who desire to install a past version of tidy-5e an easy way to do so without you having to store each version's zip in the repo itself.
