### PR TITLE
Update german locale for 0.4.x

### DIFF
--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -9,7 +9,7 @@
 	"TIDY5E.Exhaustion5": "Geschwindigkeit auf 0 reduziert",
 	"TIDY5E.Exhaustion6": "Tod",
 
-	"TIDY5E.RestHint": "Mache eine Rast",
+	"TIDY5E.RestHint": "Rasten",
 	"TIDY5E.RestS": "Kurze Rast",
 	"TIDY5E.RestL": "Lange Rast",
 
@@ -23,28 +23,28 @@
 	"TIDY5E.JournalMisc": "Verschiedenes",
 	"TIDY5E.JournalEntries": "Tagebucheinträge",
 
-	"TIDY5E.EnableEdit": "Editieren erlauben",
-	"TIDY5E.DisableEdit": "Editieren verbieten",
+	"TIDY5E.EnableEdit": "Bearbeiten erlauben",
+	"TIDY5E.DisableEdit": "Bearbeiten verbieten",
 	"TIDY5E.EditHint": "Schaltet Sichtbarkeit von Hinzufügen/Löschen Buttons und leeren Sektionen um.",
 	
 	"TIDY5E.EmptySection": "Dieser Bereich ist leer. Entsperre den Charakterbogen zum Bearbeiten.",
 	"TIDY5E.GmOnlyEdit": "Nur der Spielleiter kann diesen Bereich bearbeiten.",
 
-	"TIDY5E.AttunementWarning": "Abstimmungs-Warnung: Du kannst dich auf maximal {number} Gegenständen abstimmen!",
+	"TIDY5E.AttunementWarning": "Einstimmungs-Warnung: Du kannst dich maximal auf {number} Gegenständen einstimmen!",
 	
 	"TIDY5E.GridLayout": "Raster-Ansicht",
 	"TIDY5E.ListLayout": "Listen-Ansicht",
 
 	"TIDY5E.Encumbrance": "Traglast",
 
-	"TIDY5E.EditSpell": "Zauber editieren",
+	"TIDY5E.EditSpell": "Zauber bearbeiten",
 	"TIDY5E.DeleteSpell": "Zauber löschen",
 	"TIDY5E.AddFav": "Favorit hinzufügen",
 	"TIDY5E.isFav": "Favorit",
 	"TIDY5E.RemoveFav": "Favorit löschen",
 
 	"TIDY5E.ToggleInfo": "Info umschalten",
-	"TIDY5E.ToggleMovement": "Wechseln zwischen moderner und veralteter Geschwindigkeitsanzeige",
+	"TIDY5E.ToggleMovement": "Wechseln zwischen moderner und alter Geschwindigkeitsanzeige",
 
 	"TIDY5E.Show" : "zeigen/bearbeiten",
 	"TIDY5E.Hide" : "verstecken",
@@ -176,6 +176,10 @@
 	"TIDY5E.Settings.AlwaysShowTraits" : {
 		"name" : "Merkmale immer anzeigen.",
 		"hint" : "Standardmäßig sind leere Merkmale per Schalter ausgeblendet. Einschalten, um immer anzuzeigen."
+	},
+	"TIDY5E.Settings.ShowTraitLabels" : {
+		"name" : "Beschriftung von Merkmalen.",
+		"hint" : "Standardmäßig werden nur Icons für Merkmale angezeigt. Einschalten, um auch Beschriftungen für Merkmale anzuzeigen."
 	},
 	"TIDY5E.Settings.AlwaysShowSkills" : {
 		"name" : "Fähigkeiten immer anzeigen.",


### PR DESCRIPTION
Added `TIDY5E.Settings.ShowTraitLabels` and improved a few other translations. Attunement is now translated as it is in the german sourcebooks, and for `edit` the same translation is used everywhere for consistency instead of two different synonyms.

**Things missing translation keys:**
- The new `Attuned items` indicator (sun icon in the bottom left corner of inventory screen) with its tooltip(s)
-  [tidy5e-favorites.js#L346](https://github.com/sdenec/tidy5e-sheet/blob/eb4c7cb20de2a3693e077be8b704caf60cf66589/src/scripts/app/tidy5e-favorites.js#L346) - maybe there's more similar cases? Haven't looked yet.
- Abbreviations for currency in inventory (`CP` should be `KM` in german, for example)

Thanks for Tidy5ESheet, our group loves it 🎉

