### PR TITLE
Fixed scrollbars in Firefox

### DIFF
--- a/src/_scss/partials/_general.scss
+++ b/src/_scss/partials/_general.scss
@@ -123,4 +123,5 @@
 		list-style: none;
 		margin: 0;
 		padding: 0;
+		scrollbar-width: thin;
 	}

--- a/src/_scss/partials/_tabs.scss
+++ b/src/_scss/partials/_tabs.scss
@@ -1,6 +1,8 @@
 .window-content .tab {
 	height: 100%;
 	flex-direction: column;
+	scrollbar-width: thin;
+  	scrollbar-color: #782e22 #0000;
 
 	&.active {
 	  display: flex;

--- a/src/css/tidy5e.css
+++ b/src/css/tidy5e.css
@@ -234,6 +234,7 @@
   list-style: none;
   margin: 0;
   padding: 0;
+  scrollbar-width: thin;
 }
 
 .tidy5e.sheet.actor #item-info-container {
@@ -1847,6 +1848,8 @@
 .tidy5e.sheet.actor .window-content .tab {
   height: 100%;
   flex-direction: column;
+  scrollbar-width: thin;
+  scrollbar-color: #782e22 #0000;
 }
 
 .tidy5e.sheet.actor .window-content .tab.active {


### PR DESCRIPTION
Scrollbars are not showing properly in Firefox (screenshots below).
Without overflow:
![imagen](https://user-images.githubusercontent.com/14858594/115450723-93f4a580-a21c-11eb-9355-0cbe4e554e01.png)
With overflow:
![imagen](https://user-images.githubusercontent.com/14858594/115450799-a7077580-a21c-11eb-96a6-efaace42d4a8.png)

Due to the lack of support for **::-webkit-scrollbar-thumb** in Firefox (more info in [this post](https://stackoverflow.com/questions/6165472/custom-css-scrollbar-for-firefox)), I've made a quick fix to hide the scrollbar when there is no overflow and give it a better look when there is overflow:
![imagen](https://user-images.githubusercontent.com/14858594/115451490-8b509f00-a21d-11eb-94f2-98c1b0442922.png)
