### PR TITLE
0.5.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,15 @@ Thank you very much!
 
 ## Version History ##
 
+### Version 0.5.3 ###
+
+- fixed alphabetical skill sorting for translations
+- fixed attunement tracker
+- fixed type selection for NPCs with empty type attribute
+- fixed ability rolls for observer (PC/NPC)
+
+- in sensitive data mode the skill list will keep proficiency marks while sheet is locked but prevent toggling them
+
 ### Version 0.5.2 ###
 
 - Fix for some NPC sheets not opening due to DEFAULT_TOKEN error

--- a/module.json
+++ b/module.json
@@ -5,7 +5,7 @@
 	"version": "0.5.0",
 	"author": "sdenec#3813",
 	"minimumCoreVersion": "0.8.3",
-	"compatibleCoreVersion": "0.8.3",
+	"compatibleCoreVersion": "0.8.6",
 	"system": ["dnd5e"],
 	"esmodules": [
 		"./scripts/tidy5e-sheet.js",

--- a/src/_scss/partials/_main-tab.scss
+++ b/src/_scss/partials/_main-tab.scss
@@ -57,6 +57,13 @@
 				i {
 					vertical-align: baseline;
 				}
+
+				&:not(.proficiency-toggle) {
+					cursor: default;
+					&:hover {
+						color: var(--tertiary-color);
+					}
+				}
 			}
 
 			.skill-mod,

--- a/src/css/tidy5e.css
+++ b/src/css/tidy5e.css
@@ -1940,6 +1940,14 @@
   vertical-align: baseline;
 }
 
+.tidy5e.sheet.actor .skills-list .skill .skill-proficiency:not(.proficiency-toggle) {
+  cursor: default;
+}
+
+.tidy5e.sheet.actor .skills-list .skill .skill-proficiency:not(.proficiency-toggle):hover {
+  color: var(--tertiary-color);
+}
+
 .tidy5e.sheet.actor .skills-list .skill .skill-mod,
 .tidy5e.sheet.actor .skills-list .skill .skill-passive {
   text-align: right;

--- a/src/module.json
+++ b/src/module.json
@@ -5,7 +5,7 @@
 	"version": "0.5.0",
 	"author": "sdenec#3813",
 	"minimumCoreVersion": "0.8.3",
-	"compatibleCoreVersion": "0.8.3",
+	"compatibleCoreVersion": "0.8.6",
 	"system": "dnd5e",
 	"esmodules": [
 		"./scripts/tidy5e-sheet.js",

--- a/src/scripts/app/listeners.js
+++ b/src/scripts/app/listeners.js
@@ -56,14 +56,14 @@ export const tidy5eListeners = function (html, actor) {
   });
 
   // Modificator Ability Test Throw
-  html.find('.ability-mod').click( async (event) => {
+  html.find('.ability-mod.rollable').click( async (event) => {
     event.preventDefault();
     let ability = event.currentTarget.parentElement.parentElement.dataset.ability;
     actor.rollAbilityTest(ability, {event: event});
   });
 
   // Modificator Ability Saving Throw
-  html.find('.ability-save').click( async (event) => {
+  html.find('.ability-save.rollable').click( async (event) => {
     event.preventDefault();
     let ability = event.currentTarget.parentElement.parentElement.dataset.ability;
     actor.rollAbilitySave(ability, {event: event});

--- a/src/scripts/tidy5e-sheet.js
+++ b/src/scripts/tidy5e-sheet.js
@@ -242,6 +242,7 @@ async function countInventoryItems(app, html, data){
 // count attuned items
 async function countAttunedItems(app, html, data){
 	let actor = app.actor;
+	console.log(actor)
 	// let actor = game.actors.entities.find(a => a.data._id === data.actor._id),
 	if(data.editable && !actor.compendium){
 		let	count = actor.data.data.details.attunedItemsCount;
@@ -255,13 +256,7 @@ async function countAttunedItems(app, html, data){
 		}
 
 		let items = actor.data.items;
-		let attunedItems = 0;
-
-		for (var i = 0; i < items.length; i++){
-			if (items[i].data.attunement == 2){
-				attunedItems++;
-			}
-		}
+		let attunedItems = items.filter(item => item.data.data.attunement === 2).length;
 
 		await actor.update({"data.details.attunedItemsCount": attunedItems});
 
@@ -310,7 +305,8 @@ async function editProtection(app, html, data) {
 		
 		if(game.settings.get("tidy5e-sheet", "editTotalLockEnabled")){
 			html.find(".skill input").prop('disabled', true);
-			html.find(".skill .proficiency-toggle").remove();
+			// html.find(".skill .proficiency-toggle").remove();
+			html.find(".skill .proficiency-toggle").removeClass('proficiency-toggle');
 			html.find(".ability-score").prop('disabled', true);
 			html.find(".ac-display input").prop('disabled', true);
 			html.find(".initiative input").prop('disabled', true);

--- a/src/templates/actors/tidy5e-npc.html
+++ b/src/templates/actors/tidy5e-npc.html
@@ -109,7 +109,7 @@
               </li>
             </ul>
             <span class="creature-type" title="{{labels.type}}">
-              <a class="config-button" data-action="type" title="{{localize 'DND5E.CreatureTypeConfig'}}">{{labels.type}}</a>
+              <a class="config-button" data-action="type" title="{{localize 'DND5E.CreatureTypeConfig'}}">{{#if (eq labels.type '')}} {{localize 'DND5E.CreatureType'}} {{else}} {{labels.type}} {{/if}}</a>
             </span>
             <span class="environment" title="{{ localize 'TIDY5E.Environment' }}"><i class="fas fa-tree"></i><span class="environment-label"><span contenteditable="true" spellcheck="false" data-target="{{actor._id}}-environment" data-placeholder="{{ localize 'TIDY5E.Environment' }}" data-maxlength="80">{{data.details.environment}}</span></span></span>
             <span contenteditable="true" spellcheck="false" data-target="{{actor._id}}-alignment" data-placeholder="{{ localize 'DND5E.Alignment' }}">{{data.details.alignment}}</span>
@@ -170,11 +170,11 @@
                   <input class="ability-score" name="data.abilities.{{id}}.value" type="text" value="{{ability.value}}" data-dtype="Number" placeholder="10">
                 </div>
                 <div class="ability-modifiers value-footer">
-                  <span class="ability-mod" title="{{ localize 'DND5E.AbilityModifier' }}">{{numberFormat ability.mod decimals=0 sign=true}}</span>
+                  <span class="ability-mod rollable" title="{{ localize 'DND5E.AbilityModifier' }}">{{numberFormat ability.mod decimals=0 sign=true}}</span>
                   <input type="hidden" name="data.abilities.{{id}}.proficient" value="{{ability.proficient}}" data-dtype="Number">
                   <a class="proficiency-toggle ability-proficiency" title="{{ localize 'DND5E.Proficiency' }}">
                   {{{ability.icon}}}</a>
-                  <span class="ability-save" title="{{ localize 'DND5E.ActionSave' }}">{{numberFormat ability.save decimals=0 sign=true}}</span>
+                  <span class="ability-save rollable" title="{{ localize 'DND5E.ActionSave' }}">{{numberFormat ability.save decimals=0 sign=true}}</span>
                 </div>
                 <span class="mod-label ability-mod-label">{{ localize 'TIDY5E.AbbrMod' }}</span>
                 <span class="mod-label save-mod-label">{{ localize 'TIDY5E.AbbrSavingThrow' }}</span>

--- a/src/templates/actors/tidy5e-sheet.html
+++ b/src/templates/actors/tidy5e-sheet.html
@@ -238,11 +238,11 @@
 									<input class="ability-score" name="data.abilities.{{id}}.value" type="text" value="{{ability.value}}" data-dtype="Number" placeholder="10">
 								</div>
 								<div class="ability-modifiers value-footer">
-									<span class="ability-mod" title="{{ localize 'DND5E.AbilityModifier' }}">{{numberFormat ability.mod decimals=0 sign=true}}</span>
+									<span class="ability-mod rollable" title="{{ localize 'DND5E.AbilityModifier' }}">{{numberFormat ability.mod decimals=0 sign=true}}</span>
 									<input type="hidden" name="data.abilities.{{id}}.proficient" value="{{ability.proficient}}" data-dtype="Number">
 									<a class="proficiency-toggle ability-proficiency" title="{{ localize 'DND5E.Proficiency' }}">
 										{{{ability.icon}}}</a>
-									<span class="ability-save" title="{{ localize 'DND5E.ActionSave' }}">{{numberFormat ability.save decimals=0 sign=true}}</span>
+									<span class="ability-save rollable" title="{{ localize 'DND5E.ActionSave' }}">{{numberFormat ability.save decimals=0 sign=true}}</span>
 								</div>
 								<span class="mod-label ability-mod-label">{{ localize 'TIDY5E.AbbrMod' }}</span>
 								<span class="mod-label save-mod-label">{{ localize 'TIDY5E.AbbrSavingThrow' }}</span>
@@ -279,15 +279,17 @@
 
 					{{!-- Skills --}}
 					<ul class="skills-list">
-						{{#each data.skills as |skill s|}}
+            {{#each config.skills as |label s|}}
+            {{#with (lookup ../data.skills s) as |skill|}}
 						<li class="skill {{#if skill.value}}proficient{{/if}}" data-skill="{{s}}">
 							<input type="hidden" name="data.skills.{{s}}.value" value="{{skill.value}}" data-dtype="Number">
 							<a class="proficiency-toggle skill-proficiency" title="{{skill.hover}}">{{{skill.icon}}}</a>
-							<h4 class="skill-name rollable">{{skill.label}}</h4>
+							<h4 class="skill-name rollable">{{label}}</h4>
 							<span class="skill-ability">{{skill.ability}}</span>
 							<span class="skill-mod">{{numberFormat skill.total decimals=0 sign=true}}</span>
-							<span class="skill-passive" title="{{skill.label}} ({{ localize 'DND5E.Passive' }})">({{skill.passive}})</span>
+							<span class="skill-passive" title="{{label}} ({{ localize 'DND5E.Passive' }})">({{skill.passive}})</span>
 						</li>
+						{{/with}}
 						{{/each}}
 					</ul>
 


### PR DESCRIPTION
- fixed alphabetical skill sorting for translations
- fixed attunement tracker
- fixed type selection for NPCs with empty type attribute
- fixed ability rolls for observer (PC/NPC)

- in sensitive data mode the skill list will keep proficiency marks while sheet is locked but prevent toggling them