### PR TITLE
Add selector for switching ammo on ranged weapons

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -226,6 +226,10 @@
 		"name" : "Move traits below resources.",
 		"hint" : "Enable to move traits from the left side below resources."
 	},
+	"TIDY5E.Settings.AmmoEquippedOnly" : {
+		"name" : "Only show equipped ammunition.",
+		"hint" : "Enable to only show currently equipped ammunition in Weapon ammo selector."
+	},
 
 
 	"TIDY5E.Settings.TraitsAlwaysShown" : {

--- a/src/scripts/app/settings.js
+++ b/src/scripts/app/settings.js
@@ -90,6 +90,7 @@ export class Tidy5eUserSettings extends FormApplication {
 			'editEffectsGmOnlyEnabled',
 			'editGmAlwaysEnabled',
 			
+			'ammoEquippedOnly',
 			'journalTabDisabled',
 			'playerNameEnabled',
 			'classListDisabled',

--- a/src/scripts/app/settingsList.js
+++ b/src/scripts/app/settingsList.js
@@ -190,6 +190,15 @@ export function settingsList(){
 			default: false,
 			type: Boolean
 		});
+
+		game.settings.register("tidy5e-sheet", "ammoEquippedOnly", {
+			name: `${game.i18n.localize("TIDY5E.Settings.AmmoEquippedOnly.name")}`,
+			hint: game.i18n.localize("TIDY5E.Settings.AmmoEquippedOnly.hint"),
+			scope: "user",
+			config: false,
+			default: false,
+			type: Boolean
+		});
 	
 	
 		// NPC Sheet Settings

--- a/src/scripts/tidy5e-sheet.js
+++ b/src/scripts/tidy5e-sheet.js
@@ -66,11 +66,45 @@ export class Tidy5eSheet extends ActorSheet5eCharacter {
 		
 		let actor = this.actor;
 
-    tidy5eListeners(html, actor);
-    tidy5eContextMenu(html);
+		tidy5eListeners(html, actor);
+		tidy5eContextMenu(html);
 		tidy5eSearchFilter(html, actor);
 		tidy5eShowActorArt(html, actor);
 		tidy5eItemCard(html, actor);
+
+		html.find('.ammo').each(function () {
+			const element = $(this);
+			const itemId = element.attr('data-id');
+			const actor = game.actors.find(x => x.items.some(b => b.id === itemId));
+			const item = actor.items.get(itemId);
+			const equippedOnly = game.settings.get('tidy5e-sheet', 'ammoEquippedOnly');
+			const ammoItems = actor.items.filter(x => x.data.data.consumableType === "ammo" && (!equippedOnly || x.data.data.equipped));
+			const target = item.data.data.consume.target;
+			const ammoItemStrings = ['<option value=""></option>']
+				.concat(ammoItems.map(x => `<option value="${x.id}" ${x.id === target ? 'selected' : ''}>${x.name}</option>`))
+				.join('');
+			const selector = $(`<select style="height:unset;margin-left:0.25em;">${ammoItemStrings}</select>`);
+			selector.attr('data-item', item.id);
+			selector.attr('data-actor', actor.id);
+			selector.on('change', function () {
+				const element = $(this);
+				const val = element.val();
+				const actor = game.actors.get(selector.attr('data-actor'));
+				const item = actor.items.get(selector.attr('data-item'));
+				const ammo = actor.items.get(val);
+				item.update({
+					data: {
+						consume: {
+							amount: !ammo ? null : !!item.data.data.consume.amount ? item.data.data.consume.amount : 1,
+							target: !ammo ? '' : val,
+							type: !ammo ? '' : ammo.data.data.consumableType
+						}
+					}
+				});
+			});
+			element.after(selector);
+			element.remove();
+		});
 
 		// store Scroll Pos
 		const attributesTab = html.find('.tab.attributes');

--- a/src/templates/actors/parts/tidy5e-inventory.html
+++ b/src/templates/actors/parts/tidy5e-inventory.html
@@ -39,6 +39,9 @@
             <h4 title="{{localize 'TIDY5E.ToggleInfo'}} ({{item.name}})">
               {{item.name}}
             </h4>
+            {{#if item.data.properties.amm}}
+            <span class="ammo" data-id="{{item._id}}"></span>
+            {{/if}}
             <span class="item-quantity{{#if item.isStack}} isStack{{/if}}">
               (<input class="item-count" data-path="data.quantity" type="text" value="{{item.data.quantity}}" maxlength="3" >)
             </span>

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -90,6 +90,13 @@
         <p class="notes">{{localize 'TIDY5E.Settings.TraitsMovedBelowResource.hint'}}</p>
       </div>
     </article>
+    <article class="setting">
+      <input type="checkbox" data-dtype='boolean' name='ammoEquippedOnly' id='ammoEquippedOnly' {{checked settings.ammoEquippedOnly.value}}>
+      <div class="description">
+        <label for="ammoEquippedOnly">{{localize 'TIDY5E.Settings.AmmoEquippedOnly.name'}}</label>
+        <p class="notes">{{localize 'TIDY5E.Settings.AmmoEquippedOnly.hint'}}</p>
+      </div>
+    </article>
 	</section>
 
   


### PR DESCRIPTION
I wanted my players to be able to easily switch the ammo for their weapons directly from inventory, so I've added a simple selector to do that. This way they don't need to open the item editor and find the ammunition field to change it.

Use Case: The player has several types arrows (regular, fire, +1, etc.) and they would like to switch back and forth between the different types.

![image](https://user-images.githubusercontent.com/3588046/122837366-f2dca680-d2c1-11eb-99f1-57e4d28a42b0.png)
