### PR TITLE
Add ammo dropdown to NPCs

### DIFF
--- a/src/scripts/app/ammo-switch.js
+++ b/src/scripts/app/ammo-switch.js
@@ -3,8 +3,8 @@ export const tidy5eAmmoSwitch = function (html, actor) {
   html.find('.ammo').each(function () {
     const element = $(this);
     const itemId = element.attr('data-id');
-    const token = actor.token || null
-    if (token) actor = actor.getActiveTokens(false, true).find(t => t.data._id === token.id).actor // get synthetic actor
+    const token = actor.token || null;
+    if (token) actor = actor.getActiveTokens(false, true).find(t => t.data._id === token.id).actor; // get synthetic actor
     const item = actor.items.get(itemId);
     const equippedOnly = game.settings.get('tidy5e-sheet', 'ammoEquippedOnly');
     const ammoItems = actor.items.filter(x => x.data.data.consumableType === "ammo" && (!equippedOnly || x.data.data.equipped));
@@ -20,7 +20,8 @@ export const tidy5eAmmoSwitch = function (html, actor) {
       const element = $(this);
       const val = element.val();
       let actor = game.actors.get(selector.attr('data-actor'));
-      if (token) actor = actor.getActiveTokens(false, true).find(t => t.data._id === selector.attr('data-token')).actor // get synthetic actor
+      const token = selector.attr('data-token');
+      if (token) actor = actor.getActiveTokens(false, true).find(t => t.data._id === token).actor; // get synthetic actor
       const item = actor.items.get(selector.attr('data-item'));
       const ammo = actor.items.get(val);
       item.update({

--- a/src/scripts/app/ammo-switch.js
+++ b/src/scripts/app/ammo-switch.js
@@ -3,7 +3,8 @@ export const tidy5eAmmoSwitch = function (html, actor) {
   html.find('.ammo').each(function () {
     const element = $(this);
     const itemId = element.attr('data-id');
-    const actor = game.actors.find(x => x.items.some(b => b.id === itemId));
+    const token = actor.token || null
+    if (token) actor = actor.getActiveTokens(false, true).find(t => t.data._id === token.id).actor // get synthetic actor
     const item = actor.items.get(itemId);
     const equippedOnly = game.settings.get('tidy5e-sheet', 'ammoEquippedOnly');
     const ammoItems = actor.items.filter(x => x.data.data.consumableType === "ammo" && (!equippedOnly || x.data.data.equipped));
@@ -14,10 +15,12 @@ export const tidy5eAmmoSwitch = function (html, actor) {
     const selector = $(`<select class="ammo-switch">${ammoItemStrings}</select>`);
     selector.attr('data-item', item.id);
     selector.attr('data-actor', actor.id);
+    if (token) selector.attr('data-token', token.id);
     selector.on('change', function () {
       const element = $(this);
       const val = element.val();
-      const actor = game.actors.get(selector.attr('data-actor'));
+      let actor = game.actors.get(selector.attr('data-actor'));
+      if (token) actor = actor.getActiveTokens(false, true).find(t => t.data._id === selector.attr('data-token')).actor // get synthetic actor
       const item = actor.items.get(selector.attr('data-item'));
       const ammo = actor.items.get(val);
       item.update({

--- a/src/scripts/tidy5e-npc.js
+++ b/src/scripts/tidy5e-npc.js
@@ -7,6 +7,7 @@ import { tidy5eContextMenu } from "./app/context-menu.js";
 import { tidy5eClassicControls } from "./app/classic-controls.js";
 import { tidy5eShowActorArt } from "./app/show-actor-art.js";
 import { tidy5eItemCard } from "./app/itemcard.js";
+import { tidy5eAmmoSwitch } from "./app/ammo-switch.js";
 
 
 /**
@@ -171,6 +172,7 @@ export default class Tidy5eNPC extends ActorSheet5eNPC {
     if(game.settings.get("tidy5e-sheet", "itemCardsForNpcs")) {
       tidy5eItemCard(html, actor);
     }
+    tidy5eAmmoSwitch(html, actor);
 
     
     html.find(".toggle-personality-info").click( async (event) => {

--- a/src/templates/actors/parts/tidy5e-features.html
+++ b/src/templates/actors/parts/tidy5e-features.html
@@ -56,6 +56,9 @@
           <h4 title="{{localize 'TIDY5E.ToggleInfo'}} ({{item.name}})">
             {{item.name}}
           </h4>
+          {{#if item.data.properties.amm}}
+          <span class="ammo" data-id="{{item._id}}"></span>
+          {{/if}}
           {{#unless ../../isCharacter}}
           {{#if item.data.quantity}}
           <span class="item-quantity{{#if item.isStack}} isStack{{/if}}">


### PR DESCRIPTION
Hi,

Simple PR.
Adding ammo dropdown to NPCs and making sure we retrieve the synthetic actor instead of the original actor if the sheet originates from an unlinked token.