### PR TITLE
Feat npcs uses actions

### DIFF
--- a/src/_scss/partials/_inventory.scss
+++ b/src/_scss/partials/_inventory.scss
@@ -970,6 +970,10 @@
 			color: var(--secondary-color);
 			overflow: hidden;
 
+			&.no-border {
+				border-left-color: transparent;
+			}
+
 			span.truncate {
 				white-space: nowrap;
 				overflow: hidden;

--- a/src/css/tidy5e.css
+++ b/src/css/tidy5e.css
@@ -3278,6 +3278,10 @@
   overflow: hidden;
 }
 
+.tidy5e.sheet.actor .list-layout .items-list .item-detail.no-border {
+  border-left-color: transparent;
+}
+
 .tidy5e.sheet.actor .list-layout .items-list .item-detail span.truncate {
   white-space: nowrap;
   overflow: hidden;

--- a/src/scripts/tidy5e-npc.js
+++ b/src/scripts/tidy5e-npc.js
@@ -67,7 +67,7 @@ export default class Tidy5eNPC extends ActorSheet5eNPC {
       passive: { label: game.i18n.localize("DND5E.Features"), items: [], dataset: {type: "feat"} },
       weapons: { label: game.i18n.localize("DND5E.AttackPl"), items: [] , hasActions: true, dataset: {type: "weapon", "weapon-type": "natural"} },
       actions: { label: game.i18n.localize("DND5E.ActionPl"), items: [] , hasActions: true, dataset: {type: "feat", "activation.type": "action"} },
-      equipment: { label: game.i18n.localize("DND5E.Inventory"), items: [], dataset: {type: "loot"}}
+      equipment: { label: game.i18n.localize("DND5E.Inventory"), items: [], hasActions: true, dataset: {type: "loot"}}
     };
 
     // Start by classifying items into groups for rendering
@@ -104,6 +104,24 @@ export default class Tidy5eNPC extends ActorSheet5eNPC {
       else features.equipment.items.push(item);
     }
 
+    // Sort others equipements type
+    const sortingOrder = {
+      'equipment': 1,
+      'consumable': 2
+    };
+
+    features.equipment.items.sort((a, b) => {
+      if (!a.hasOwnProperty('type') || !b.hasOwnProperty('type')) return 0;
+
+      const first = (a['type'].toLowerCase() in sortingOrder) ? sortingOrder[a['type']] : Number.MAX_SAFE_INTEGER;
+      const second = (b['type'].toLowerCase() in sortingOrder) ? sortingOrder[b['type']] : Number.MAX_SAFE_INTEGER;
+
+      let result = 0;
+      if (first < second) result = -1;
+      else if (first > second) result = 1;
+
+      return result
+    });
 
     // Assign and return
     data.features = Object.values(features);

--- a/src/templates/actors/parts/tidy5e-features.html
+++ b/src/templates/actors/parts/tidy5e-features.html
@@ -72,7 +72,7 @@
         {{/if}}
 
         {{#if section.hasActions}}
-        <div class="item-detail item-charges">
+        <div class="item-detail item-charges {{#if ../../isNPC}}{{#unless item.hasUses}} no-border{{/unless}}{{/if}}">
           {{#if item.isOnCooldown}}
           <a class="item-recharge rollable" title="{{item.labels.recharge}}"><i class="fas fa-dice-six"></i> {{item.data.recharge.value}}{{#if (ne item.data.recharge.value 6)}}+{{/if}}</a>
           {{else if item.data.recharge.value}}
@@ -80,12 +80,12 @@
 
           {{else if item.hasUses}}
           <input data-path="data.uses.value" type="text" value="{{item.data.uses.value}}">/ <input  class="uses-max" data-path="data.uses.max" type="text" value="{{item.data.uses.max}}">
-          {{else}}
+          {{else unless ../../isNPC}}
           <a class="addCharges" value="Add">Add</a>
           {{/if}}
         </div>
 
-        <div class="item-detail item-action">
+        <div class="item-detail item-action {{#if ../../isNPC}}{{#unless item.data.activation.type}} no-border{{/unless}}{{/if}}">
           {{#if item.data.activation.type }}
           {{item.labels.activation}}
           {{/if}}


### PR DESCRIPTION
Hi,

First, I realize that it was more a feature than a bug :)
But I feel that NPC's equipments need uses & actions. Especially for magic items and such.

This PR has two commits:

**First commit:**
- Add uses and actions to NPC's equipment
- Sort NPC's equipment:
-- "Equipments" first, as these are usually where magic items fall in.
-- Then "ammunition", then the rest.
-- I feel that in the heat of a combat, it's more intuitive for the GM to have these two categories at the top of the inventory section.
-- Also, I added that specific order because it is very difficult for a GM to manually order items in the inventory section. The way items are divided at runtime makes it so, that some items in the inventory are virtually impossible to put first in the inventory list.

**Second commit:**
- Removing all left borders in the list of uses & actions when no use or action is declared on the item. Also remove the "Add" button when no use is declared.
- Made that because:
-- NPCs are generally created before a session and not often modified during the session (unlike PCs)
-- To prevent errors in the heat of combat, during a session
- That last commit is very optional 