### PR TITLE
Sheet width config

### DIFF
--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -112,33 +112,9 @@
 	"TIDY5E.Settings.VehicleLabel" : "Fahrzeuge",
 
 	"TIDY5E.Settings.SheetMenu" : {
-		"label" : "Einstellungen für Charakterbögen",
-		"title" : "Tidy5e Charakterbogeneinstellungen"
+		"label" : "Einstellungen für Charakterbögen"
 	},
-	"TIDY5E.Settings.TabPlayers" : {
-		"tabLabel" : "Spieler",
-		"header" : "Spieler Charakterbögen"
-	},
-	"TIDY5E.Settings.TabNPCsVehicles" : {
-		"tabLabel" : "NSCs/Fahrzeuge",
-		"header" : "NSC/Fahrzeugbögen",
-		"labelNPCs" : "NSCs",
-		"labelVehicles" : "Fahrzeuge"
-	},
-	"TIDY5E.Settings.TabGM" : {
-		"tabLabel" : "SL Optionen",
-		"header" : "SL Bogene Optionen"
-	},
-	"TIDY5E.Settings.TabModules" : {
-		"tabLabel" : "Module",
-		"header" : "Modul Optionen",
-		"labelActionsFavorites" : "Akteur Aktionen/Favoriten",
-		"labelMidiQoL" : "Midi Qol"
-	},
-	"TIDY5E.Settings.TabInfo" : {
-		"tabLabel" : "Info",
-		"header" : "Info"
-	},	
+	
 	"TIDY5E.Settings.ItemCardsForAllItems" : {
 		"name" : "Zeigen Gegenstand-Infokarten in allen Ansichten.",
 		"hint" : "Deaktivieren wenn Infokarten nur in der Rasteransicht gezeigt werden sollen."
@@ -160,7 +136,6 @@
 		"hint" : "Gib eine Taste (z. B.: x) für die Infokarten-Interaktion ein. Alle Tasten außer Funktionstasten (ctrl, alt, etc.) möglich"
 	},
 	
-
 	"TIDY5E.Settings.SheetTheme" : {
 		"name" : "Tidy5e Farbschema.",
 		"hint" : "Nutze das helle Standarschema oder das dunkle Alternativschema von Tidy5e.",
@@ -175,21 +150,18 @@
 	"TIDY5E.Settings.RollButtonsToCard" : {
 		"name" : "Zeige midiQol Gegenstand-Buttons in der Info-Karte",
 		"hint" : "Standardmäßig werden Gegenstands-Buttons in den Zusatzinfos angezeigt. Aktivieren, um sie in die Info-Karte zu verschieben. Funktioniert in allen Layout-Modi."
-	},	
+	},
+	
 	"TIDY5E.Settings.TraitLabels" : {
 		"name" : "Beschriftung von Merkmalen.",
 		"hint" : "Standardmäßig werden nur Icons für Merkmale angezeigt. Einschalten, um auch Beschriftungen für Merkmale anzuzeigen."
 	},
 	
-	
-	"TIDY5E.Settings.PlayerName" : {
-		"name" : "Zeige Spielername.",
-		"hint" : "Aktiviere, um ein Feld für den Namen des Spielers unterhalb des Charakternamens anzuzeigen."
-	},
 	"TIDY5E.Settings.JournalTab" : {
 		"name" : "Charakter-Tagebuch verstecken.",
 		"hint" : "Aktivieren, um den Tagebuch-Reiter zu verstecken."
 	},
+
 	"TIDY5E.Settings.ClassList" : {
 		"name" : "Charakter-Klassenliste verstecken.",
 		"hint" : "Einschalten, um die Klassenliste unter dem Namen eines Charakters zu verstecken."
@@ -212,7 +184,7 @@
 	},
 	"TIDY5E.Settings.HpBar" : {
 		"name" : "Lebensbalken deaktivieren.",
-		"hint" : "Einschalten, um den farbigen Balken zur Anzeige des Rest-Lebens unter dem Portrait zu deaktivieren (Trefferpunkte bleiben weiter sichtbar)."
+		"hint" : "Aktivieren, um den farbigen Balken zur Anzeige des Rest-Lebens unter dem Portrait zu deaktivieren (Trefferpunkte bleiben weiter sichtbar)."
 	},
 	"TIDY5E.Settings.HpOverlay" : {
 		"name" : "Trefferpunkt-Overlay verstecken.",
@@ -226,12 +198,6 @@
 		"name" : "Verschiebe Merkmale unter Ressourcen.",
 		"hint" : "Einschalten, um Merkmalliste von der linken Seite unter die Ressourcen zu verschieben."
 	},
-	"TIDY5E.Settings.AmmoEquippedOnly" : {
-		"name" : "Zeige nur ausgerüstete Munition.",
-		"hint" : "Einschalten, um nur die aktuell ausgerüstete Munition in der Waffen-Munitionsauswahl anzuzeigen."
-	},
-
-
 	"TIDY5E.Settings.TraitsAlwaysShown" : {
 		"name" : "Merkmale immer anzeigen.",
 		"hint" : "Standardmäßig sind leere Merkmale per Schalter ausgeblendet. Einschalten, um immer anzuzeigen."
@@ -240,7 +206,6 @@
 		"name" : "Fähigkeiten immer anzeigen.",
 		"hint" : "Standardmäßig sind ungeübte Fähigkeiten per Schalter ausgeblendet. Einschalten, um immer anzuzeigen."
 	},
-
 
 	"TIDY5E.Settings.ActiveEffectsMarker" : {
 		"name" : "Zeige Marker für Gegenstände mit Aktiven Effekten.",
@@ -260,7 +225,6 @@
 		"all": "Alle Darsteller",
 		"pc": "Nur für SCs",
 		"npc": "Nur für NSCs/Fahrzeuge",
-		"none": "Keine",
 		"default": "Keine"
 	},
 	"TIDY5E.Settings.HpOverlayBorder" : {
@@ -321,7 +285,6 @@
 		"hint" : "Fügt farbige Rahmen und Icons zu verknüpften/unverknüpften NSC-Bögen hinzu.",
 		"default": "Kein Verknüpfungsmarker (standard)",
 		"unlinked": "Unverknüpfte Token hervorheben",
-		"linked": "Verknüpfte Token hervorheben",
 		"both": "Verknüpfte und unverknüpfte Token hervorheben"
 	},
 	"TIDY5E.Settings.DefaultActionsTab" : {
@@ -330,8 +293,16 @@
 		"default": "Aktionen",
 		"attributes": "Attribute"
 	},
-	"TIDY5E.Settings.HiddenDeathSaves" : {
-		"name" : "Verstecke Todesrettungswürfe vor Spielern.",
-		"hint" : "Einschalten, um Todesrettungswürfe und ihre Ergebnise nur für den SL Sichtbar zu machen."
+	"TIDY5E.Settings.npsSheetWidth" : {
+		"name" : "Standard Breite des NSC Bogens.",
+		"hint" : "Die Breite des NSC Bogens in Pixeln, benötigt ein Neuladen der Seite (standard 740)."
+	},
+	"TIDY5E.Settings.playerSheetWidth" : {
+		"name" : "Standard Breite des Spieler Bogens.",
+		"hint" : "Die Breite des Spieler Bogens in Pixeln, benötigt ein Neuladen der Seite (standard 740)."
+	},
+	"TIDY5E.Settings.vehicleSheetWidth" : {
+		"name" : "Standard Breite des Fahrzeug Bogens.",
+		"hint" : "Die Breite des Fahrzeug Bogens in Pixeln, benötigt ein Neuladen der Seite (standard 740)."
 	}
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -333,5 +333,17 @@
 	"TIDY5E.Settings.HiddenDeathSaves" : {
 		"name" : "Hide Death Saves from Players.",
 		"hint" : "Enable to make Death Saves and Death Save Results only visible to the GM"
+	},
+	"TIDY5E.Settings.npsSheetWidth" : {
+		"name" : "Default NPC sheet width.",
+		"hint" : "The width of the NPC sheet in pixels, requires a refresh to take effect (default 740)."
+	},
+	"TIDY5E.Settings.playerSheetWidth" : {
+		"name" : "Default player sheet width.",
+		"hint" : "The width of the player sheet in pixels, requires a refresh to take effect (default 740)."
+	},
+	"TIDY5E.Settings.vehicleSheetWidth" : {
+		"name" : "Default vehicle sheet width.",
+		"hint" : "The width of the vehicle sheet in pixels, requires a refresh to take effect (default 740)."
 	}
 }

--- a/src/scripts/app/settings.js
+++ b/src/scripts/app/settings.js
@@ -92,6 +92,10 @@ export class Tidy5eUserSettings extends FormApplication {
 			'rightClickDisabled',
 			'skillsAlwaysShownNpc',
 
+			'playerSheetWidth',
+			'npsSheetWidth',
+			'vehicleSheetWidth',
+
 			'traitLabelsEnabled',
 			'traitsAlwaysShownNpc',
 			'traitsMovedBelowResource',

--- a/src/scripts/app/settingsList.js
+++ b/src/scripts/app/settingsList.js
@@ -537,4 +537,34 @@ export function settingsList(){
 			},
 			default: 'default'
 		});
+
+		// Default width for player sheet
+		
+		game.settings.register("tidy5e-sheet", "playerSheetWidth", {
+			name: `${game.i18n.localize("TIDY5E.Settings.playerSheetWidth")}`,
+			scope: "user",
+			config: false,
+			type: Number,
+			default: 740
+		});
+
+		// Default width for NPC sheet
+		
+		game.settings.register("tidy5e-sheet", "npsSheetWidth", {
+			name: `${game.i18n.localize("TIDY5E.Settings.npsSheetWidth")}`,
+			scope: "user",
+			config: false,
+			type: Number,
+			default: 740
+		});
+
+		// Default width for vehicle sheet
+		
+		game.settings.register("tidy5e-sheet", "vehicleSheetWidth", {
+			name: `${game.i18n.localize("TIDY5E.Settings.vehicleSheetWidth")}`,
+			scope: "user",
+			config: false,
+			type: Number,
+			default: 740
+		});
 }

--- a/src/scripts/tidy5e-npc.js
+++ b/src/scripts/tidy5e-npc.js
@@ -35,7 +35,7 @@ export default class Tidy5eNPC extends ActorSheet5eNPC {
 
 	  return mergeObject(super.defaultOptions, {
       classes: ["tidy5e", "sheet", "actor", "npc"],
-      width: 740,
+      width: game.settings.get("tidy5e-sheet", "npsSheetWidth") ?? 740,
       height: 720,
 			tabs: [{navSelector: ".tabs", contentSelector: ".sheet-body", initial: defaultTab}]
     });

--- a/src/scripts/tidy5e-sheet.js
+++ b/src/scripts/tidy5e-sheet.js
@@ -31,7 +31,7 @@ export class Tidy5eSheet extends ActorSheet5eCharacter {
 	  return mergeObject(super.defaultOptions, {
 			classes: ["tidy5e", "sheet", "actor", "character"],
 			blockFavTab: true,
-			width: 740,
+			width: game.settings.get("tidy5e-sheet", "playerSheetWidth") ?? 740,
 			height: 840,
 			tabs: [{navSelector: ".tabs", contentSelector: ".sheet-body", initial: defaultTab}]
 		});

--- a/src/scripts/tidy5e-vehicle.js
+++ b/src/scripts/tidy5e-vehicle.js
@@ -15,7 +15,7 @@ export class Tidy5eVehicle extends ActorSheet5eVehicle {
 
 	  return mergeObject(super.defaultOptions, {
 			classes: ["tidy5e", "sheet", "actor", "vehicle"],
-			width: 740,
+			width: game.settings.get("tidy5e-sheet", "vehicleSheetWidth") ?? 740,
 			height: 720,
 			tabs: [{navSelector: ".tabs", contentSelector: ".sheet-body", initial: defaultTab}]
 		});

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -90,6 +90,19 @@
         <p class="notes">{{localize 'TIDY5E.Settings.AmmoEquippedOnly.hint'}}</p>
       </div>
     </article>
+    <article class="setting group">
+      <div>
+        <div class="description">
+          <label for="playerSheetWidth">{{localize 'TIDY5E.Settings.playerSheetWidth.name'}}</label>
+          <p class="notes">{{localize 'TIDY5E.Settings.playerSheetWidth.hint'}}</p>
+        </div>
+        <div class="settings-group">
+           <article>
+            <input type="number" data-dtype='number' name='playerSheetWidth' id='playerSheetWidth' value="{{settings.playerSheetWidth.value}}">
+          </article>
+        </div>
+      </div>
+    </article>
 	</section>
 
   
@@ -166,6 +179,19 @@
         <p class="notes">{{localize 'TIDY5E.Settings.SkillsAlwaysShown.hint'}}</p>
       </div>
     </article>
+    <article class="setting group">
+      <div>
+        <div class="description">
+          <label for="npsSheetWidth">{{localize 'TIDY5E.Settings.npsSheetWidth.name'}}</label>
+          <p class="notes">{{localize 'TIDY5E.Settings.npsSheetWidth.hint'}}</p>
+        </div>
+        <div class="settings-group">
+           <article>
+            <input type="number" data-dtype='number' name='npsSheetWidth' id='npsSheetWidth' value="{{settings.npsSheetWidth.value}}">
+          </article>
+        </div>
+      </div>
+    </article>
 
     <h3>{{localize 'TIDY5E.Settings.TabNPCsVehicles.labelVehicles'}}</h3>
     <article class="setting">
@@ -180,6 +206,19 @@
       <div class="description">
         <label for="hpOverlayDisabledVehicle">{{localize 'TIDY5E.Settings.HpOverlay.name'}}</label>
         <p class="notes">{{localize 'TIDY5E.Settings.HpOverlay.hint'}}</p>
+      </div>
+    </article>
+    <article class="setting group">
+      <div>
+        <div class="description">
+          <label for="vehicleSheetWidth">{{localize 'TIDY5E.Settings.vehicleSheetWidth.name'}}</label>
+          <p class="notes">{{localize 'TIDY5E.Settings.vehicleSheetWidth.hint'}}</p>
+        </div>
+        <div class="settings-group">
+           <article>
+            <input type="number" data-dtype='number' name='vehicleSheetWidth' id='vehicleSheetWidth' value="{{settings.vehicleSheetWidth.value}}">
+          </article>
+        </div>
       </div>
     </article>
 	</section>


### PR DESCRIPTION
I personally use a lot of modules, that add stuff to the title bar of the sheets, which causes some actions (especially the close) to disappear, unless I resize the sheet (everytime).
To work around this, I added settings to configure the width of the npc, player and vehicle sheets.
The settings are user based settings, so every player can set it up themselves, with the default value of 740