### PR TITLE
Update compatibleCoreVersion to "9"

### DIFF
--- a/module.json
+++ b/module.json
@@ -5,7 +5,7 @@
 	"version": "0.5.21",
 	"author": "sdenec#3813",
 	"minimumCoreVersion": "0.8.3",
-	"compatibleCoreVersion": "0.9.9",
+	"compatibleCoreVersion": "9",
 	"system": "dnd5e",
 	"esmodules": [
 		"./scripts/tidy5e-sheet.js",


### PR DESCRIPTION
The latest Core version number is `9` not `0.9.9`, so Foundry reports this module as incompatible since `0.9.9 < 9`. Core has switched to a new versioning scheme using whole number version numbers. Now `0.8.x` is retroactively v8, and the latest version is v9, the next version will be v10. New Core releases do also have a build number, and this can be specified if needed like so: `9.242` indicating Core v9, build 242 (the latest released version as of now). However, the build specificity isn't necessary in most cases, so for this PR it is omitted.

Resolves #473