### PR TITLE
Updating "Attack Mod" field to account for spell attack modifier bonuses

### DIFF
--- a/src/scripts/tidy5e-sheet.js
+++ b/src/scripts/tidy5e-sheet.js
@@ -398,8 +398,8 @@ async function spellAttackMod(app,html,data){
 				prof = actor.data.data.attributes.prof,
 				spellAbility = html.find('.spellcasting-attribute select option:selected').val(),
 				abilityMod = spellAbility != '' ? actor.data.data.abilities[spellAbility].mod : 0,
-				baseSpellAttackMod = prof + abilityMod,
-				spellAttackMod = baseSpellAttackMod + parseInt(actor.data.data.bonuses.rsak.attack),
+				spellBonus = parseInt(actor.data.data.bonuses.rsak.attack),
+				spellAttackMod = prof + abilityMod + spellBonus,
 				text = spellAttackMod > 0 ? '+'+spellAttackMod : spellAttackMod;
 		// console.log('Prof: '+prof+ '/ Spell Ability: '+spellAbility+ '/ ability Mod: '+abilityMod+'/ Spell Attack Mod:'+spellAttackMod);
 		html.find('.spell-mod .spell-attack-mod').html(text);

--- a/src/scripts/tidy5e-sheet.js
+++ b/src/scripts/tidy5e-sheet.js
@@ -398,7 +398,8 @@ async function spellAttackMod(app,html,data){
 				prof = actor.data.data.attributes.prof,
 				spellAbility = html.find('.spellcasting-attribute select option:selected').val(),
 				abilityMod = spellAbility != '' ? actor.data.data.abilities[spellAbility].mod : 0,
-				spellAttackMod = prof + abilityMod,
+				baseSpellAttackMod = prof + abilityMod,
+				spellAttackMod = baseSpellAttackMod + parseInt(actor.data.data.bonuses.rsak.attack),
 				text = spellAttackMod > 0 ? '+'+spellAttackMod : spellAttackMod;
 		// console.log('Prof: '+prof+ '/ Spell Ability: '+spellAbility+ '/ ability Mod: '+abilityMod+'/ Spell Attack Mod:'+spellAttackMod);
 		html.find('.spell-mod .spell-attack-mod').html(text);

--- a/src/scripts/tidy5e-sheet.js
+++ b/src/scripts/tidy5e-sheet.js
@@ -398,7 +398,7 @@ async function spellAttackMod(app,html,data){
 				prof = actor.data.data.attributes.prof,
 				spellAbility = html.find('.spellcasting-attribute select option:selected').val(),
 				abilityMod = spellAbility != '' ? actor.data.data.abilities[spellAbility].mod : 0,
-				spellBonus = parseInt(actor.data.data.bonuses.rsak.attack),
+				spellBonus = parseInt(actor.data.data.bonuses.rsak.attack || 0),
 				spellAttackMod = prof + abilityMod + spellBonus,
 				text = spellAttackMod > 0 ? '+'+spellAttackMod : spellAttackMod;
 		// console.log('Prof: '+prof+ '/ Spell Ability: '+spellAbility+ '/ ability Mod: '+abilityMod+'/ Spell Attack Mod:'+spellAttackMod);


### PR DESCRIPTION
I noticed that when adding bonuses to an actor's spell attack modifier (for example, if they had the Robes of the Archmagi equipped), they didn't get reflected in the display. This PR simply adds the ranged spell attack modifier to the display so that it properly displays on the sheet.

Caveat: Unfortunately, it seems that Foundry differentiates `rsak` and `msak` for ranged and melee spell attack bonuses respectively, but doesn't have any accessible field for a more general spell attack bonus. Thus, I defaulted to the _ranged_ spell attack modifier which may not be correct/desired behavior in all cases.