### PR TITLE
Fixed different background for C and R spell components

### DIFF
--- a/src/templates/actors/parts/tidy5e-npc-spellbook.html
+++ b/src/templates/actors/parts/tidy5e-npc-spellbook.html
@@ -55,7 +55,7 @@
         {{/if}}
         <div class="item-detail spell-comps">
           {{#each labels.components.all}}
-          <span class="spell-component{{#if tag}} tag{{/if}}">{{abbr}}</span>
+          <span class="spell-component{{#if tag}} {{abbr}}{{/if}}">{{abbr}}</span>
           {{/each}}
         </div>
         <!-- <div class="item-detail spell-school">{{labels.school}}</div> -->

--- a/src/templates/actors/parts/tidy5e-spellbook.html
+++ b/src/templates/actors/parts/tidy5e-spellbook.html
@@ -62,7 +62,7 @@
         {{/if}}
         <div class="item-detail spell-comps">
           {{#each labels.components.all}}
-          <span class="spell-component{{#if tag}} tag{{/if}}">{{abbr}}</span>
+          <span class="spell-component{{#if tag}} {{abbr}}{{/if}}">{{abbr}}</span>
           {{/each}}
         </div>
         <div class="item-detail spell-school" title="{{localize 'DND5E.SpellSchool'}}: {{labels.school}}"><span class="truncate">{{labels.school}}</span></div>


### PR DESCRIPTION
Concentration and Ritual components weren't getting their usual different "block" background as an highlight. This fixes the issue.