### PR TITLE
Preliminary v10 (dnd5e 2.0.0) update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 sftp-config.json
 .vscode/sftp.json
+src/*.lock

--- a/.vscode/extension.json
+++ b/.vscode/extension.json
@@ -1,3 +1,5 @@
 {
-  "recommendations": ["ritwickdey.live-sass"]
+    "recommendations": [
+        "glenn2223.live-sass"
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,18 +1,14 @@
 {
-  "liveSassCompile.settings.formats": [
-        
-
-
-
+    "liveSassCompile.settings.formats": [
         {
             "format": "expanded",
             "extensionName": ".css",
-            "savePath": "/src/css/"
+            "savePath": "/src/css"
         }
     ],
     "liveSassCompile.settings.excludeList": [
-       "**/node_modules/**",
-       ".vscode/**"
+        "/node_modules/**",
+        "/.vscode/**"
     ],
     "liveSassCompile.settings.generateMap": false,
     "liveSassCompile.settings.autoprefix": [

--- a/module.json
+++ b/module.json
@@ -1,83 +1,100 @@
 {
-	"name": "tidy5e-sheet",
-	"title": "Tidy5e Sheet",
-	"description": "Replaces the default D&D 5e character and NPC sheet with an alternate layout focused on a cleaner UI",
-	"version": "0.5.21",
-	"author": "sdenec#3813",
-	"minimumCoreVersion": "0.8.3",
-	"compatibleCoreVersion": "9",
-	"system": "dnd5e",
-	"esmodules": [
-		"./scripts/tidy5e-sheet.js",
-		"./scripts/tidy5e-npc.js",
-		"./scripts/tidy5e-vehicle.js",
-		"./scripts/tidy5e-item.js",
-		"./scripts/app/exhaustion.js"
-	],
-	"styles": [
-		"../fonts/modesto-condensed/modesto-condensed.css",
-		"./css/tidy-icons.css",
-		"./css/tidy5e.css",
-		"./css/tidy5e-dark.css"
-	],
-	"languages": [
-		{
-			"lang": "en",
-			"name": "English",
-			"path": "lang/en.json"
-		},
-		{
-			"lang": "es",
-			"name": "Español",
-			"path": "lang/es.json"
-		},
-		{
-			"lang": "de",
-			"name": "Deutsch",
-			"path": "lang/de.json"
-		},
-		{
-			"lang": "it",
-			"name": "Italian",
-			"path": "lang/it.json"
-		},
-		{
-			"lang": "ja",
-			"name": "日本語 (Japanese)",
-			"path": "lang/ja.json"
-		},
-		{
-			"lang": "ko",
-			"name": "한국어 (Korean)",
-			"path": "lang/ko.json"
-		},
-		{
-			"lang": "pt-BR",
-			"name": "Português (Brasil)",
-			"path": "lang/pt-BR.json"
-		},
-		{
-			"lang": "fr",
-			"name": "Francais",
-			"path": "lang/fr.json"
-		},
-		{
-			"lang": "zh-tw",
-			"name": "正體中文",
-			"path": "lang/zh-tw.json"
-		},
-		{
-			"lang": "cs",
-			"name": "Čeština",
-			"path": "lang/cs.json"
-		},
-		{
-			"lang": "hu",
-			"name": "Magyar",
-			"path": "lang/hu.json"
-		}
-	],
-  "url": "https://github.com/sdenec/tidy5e-sheet",
-  "manifest": "https://github.com/sdenec/tidy5e-sheet/releases/latest/download/module.json",
-  "download": "https://github.com/sdenec/tidy5e-sheet/releases/latest/download/module.zip"
+    "id": "tidy5e-sheet",
+    "title": "Tidy5e Sheet",
+    "description": "Replaces the default D&D 5e character and NPC sheet with an alternate layout focused on a cleaner UI",
+    "version": "0.5.21",
+    "authors": [
+        {
+            "name": "sdenec#3813"
+        }
+    ],
+    "compatibility": {
+        "minimum": "10",
+        "verified": "10"
+    },
+    "esmodules": [
+        "scripts/tidy5e-sheet.js",
+        "scripts/tidy5e-npc.js",
+        "scripts/tidy5e-vehicle.js",
+        "scripts/tidy5e-item.js",
+        "scripts/app/exhaustion.js"
+    ],
+    "styles": [
+        "css/tidy-icons.css",
+        "css/tidy5e.css",
+        "css/tidy5e-dark.css"
+    ],
+    "languages": [
+        {
+            "lang": "en",
+            "name": "English",
+            "path": "lang/en.json"
+        },
+        {
+            "lang": "es",
+            "name": "Español",
+            "path": "lang/es.json"
+        },
+        {
+            "lang": "de",
+            "name": "Deutsch",
+            "path": "lang/de.json"
+        },
+        {
+            "lang": "it",
+            "name": "Italian",
+            "path": "lang/it.json"
+        },
+        {
+            "lang": "ja",
+            "name": "日本語 (Japanese)",
+            "path": "lang/ja.json"
+        },
+        {
+            "lang": "ko",
+            "name": "한국어 (Korean)",
+            "path": "lang/ko.json"
+        },
+        {
+            "lang": "pt-BR",
+            "name": "Português (Brasil)",
+            "path": "lang/pt-BR.json"
+        },
+        {
+            "lang": "fr",
+            "name": "Francais",
+            "path": "lang/fr.json"
+        },
+        {
+            "lang": "zh-tw",
+            "name": "正體中文",
+            "path": "lang/zh-tw.json"
+        },
+        {
+            "lang": "cs",
+            "name": "Čeština",
+            "path": "lang/cs.json"
+        },
+        {
+            "lang": "hu",
+            "name": "Magyar",
+            "path": "lang/hu.json"
+        }
+    ],
+    "relationships": {
+        "systems": [
+            {
+                "id": "dnd5e",
+                "type": "system",
+                "manifest": "https://raw.githubusercontent.com/foundryvtt/dnd5e/v10-dev/system.json",
+                "compatibility": {
+                    "minimum": "2.0.0-alpha1",
+                    "verified": "2.0.0"
+                }
+            }
+        ]
+    },
+    "url": "https://github.com/sdenec/tidy5e-sheet",
+    "manifest": "https://github.com/sdenec/tidy5e-sheet/releases/latest/download/module.json",
+    "download": "https://github.com/sdenec/tidy5e-sheet/releases/latest/download/module.zip"
 }

--- a/src/module.json
+++ b/src/module.json
@@ -1,83 +1,100 @@
 {
-	"name": "tidy5e-sheet",
-	"title": "Tidy5e Sheet",
-	"description": "Replaces the default D&D 5e character and NPC sheet with an alternate layout focused on a cleaner UI",
-	"version": "0.5.21",
-	"author": "sdenec#3813",
-	"minimumCoreVersion": "0.8.3",
-	"compatibleCoreVersion": "9",
-	"system": "dnd5e",
-	"esmodules": [
-		"./scripts/tidy5e-sheet.js",
-		"./scripts/tidy5e-npc.js",
-		"./scripts/tidy5e-vehicle.js",
-		"./scripts/tidy5e-item.js",
-		"./scripts/app/exhaustion.js"
-	],
-	"styles": [
-		"../fonts/modesto-condensed/modesto-condensed.css",
-		"./css/tidy-icons.css",
-		"./css/tidy5e.css",
-		"./css/tidy5e-dark.css"
-	],
-	"languages": [
-		{
-			"lang": "en",
-			"name": "English",
-			"path": "lang/en.json"
-		},
-		{
-			"lang": "es",
-			"name": "Español",
-			"path": "lang/es.json"
-		},
-		{
-			"lang": "de",
-			"name": "Deutsch",
-			"path": "lang/de.json"
-		},
-		{
-			"lang": "it",
-			"name": "Italian",
-			"path": "lang/it.json"
-		},
-		{
-			"lang": "ja",
-			"name": "日本語 (Japanese)",
-			"path": "lang/ja.json"
-		},
-		{
-			"lang": "ko",
-			"name": "한국어 (Korean)",
-			"path": "lang/ko.json"
-		},
-		{
-			"lang": "pt-BR",
-			"name": "Português (Brasil)",
-			"path": "lang/pt-BR.json"
-		},
-		{
-			"lang": "fr",
-			"name": "Francais",
-			"path": "lang/fr.json"
-		},
-		{
-			"lang": "zh-tw",
-			"name": "正體中文",
-			"path": "lang/zh-tw.json"
-		},
-		{
-			"lang": "cs",
-			"name": "Čeština",
-			"path": "lang/cs.json"
-		},
-		{
-			"lang": "hu",
-			"name": "Magyar",
-			"path": "lang/hu.json"
-		}
-	],
-  "url": "https://github.com/sdenec/tidy5e-sheet",
-  "manifest": "https://github.com/sdenec/tidy5e-sheet/releases/latest/download/module.json",
-  "download": "https://github.com/sdenec/tidy5e-sheet/releases/latest/download/module.zip"
+    "id": "tidy5e-sheet",
+    "title": "Tidy5e Sheet",
+    "description": "Replaces the default D&D 5e character and NPC sheet with an alternate layout focused on a cleaner UI",
+    "version": "0.5.21",
+    "authors": [
+        {
+            "name": "sdenec#3813"
+        }
+    ],
+    "compatibility": {
+        "minimum": "10",
+        "verified": "10"
+    },
+    "esmodules": [
+        "scripts/tidy5e-sheet.js",
+        "scripts/tidy5e-npc.js",
+        "scripts/tidy5e-vehicle.js",
+        "scripts/tidy5e-item.js",
+        "scripts/app/exhaustion.js"
+    ],
+    "styles": [
+        "css/tidy-icons.css",
+        "css/tidy5e.css",
+        "css/tidy5e-dark.css"
+    ],
+    "languages": [
+        {
+            "lang": "en",
+            "name": "English",
+            "path": "lang/en.json"
+        },
+        {
+            "lang": "es",
+            "name": "Español",
+            "path": "lang/es.json"
+        },
+        {
+            "lang": "de",
+            "name": "Deutsch",
+            "path": "lang/de.json"
+        },
+        {
+            "lang": "it",
+            "name": "Italian",
+            "path": "lang/it.json"
+        },
+        {
+            "lang": "ja",
+            "name": "日本語 (Japanese)",
+            "path": "lang/ja.json"
+        },
+        {
+            "lang": "ko",
+            "name": "한국어 (Korean)",
+            "path": "lang/ko.json"
+        },
+        {
+            "lang": "pt-BR",
+            "name": "Português (Brasil)",
+            "path": "lang/pt-BR.json"
+        },
+        {
+            "lang": "fr",
+            "name": "Francais",
+            "path": "lang/fr.json"
+        },
+        {
+            "lang": "zh-tw",
+            "name": "正體中文",
+            "path": "lang/zh-tw.json"
+        },
+        {
+            "lang": "cs",
+            "name": "Čeština",
+            "path": "lang/cs.json"
+        },
+        {
+            "lang": "hu",
+            "name": "Magyar",
+            "path": "lang/hu.json"
+        }
+    ],
+    "relationships": {
+        "systems": [
+            {
+                "id": "dnd5e",
+                "type": "system",
+                "manifest": "https://raw.githubusercontent.com/foundryvtt/dnd5e/v10-dev/system.json",
+                "compatibility": {
+                    "minimum": "2.0.0-alpha1",
+                    "verified": "2.0.0"
+                }
+            }
+        ]
+    },
+    "url": "https://github.com/sdenec/tidy5e-sheet",
+    "manifest": "https://github.com/sdenec/tidy5e-sheet/releases/latest/download/module.json",
+    "download": "https://github.com/sdenec/tidy5e-sheet/releases/latest/download/module.zip"
 }

--- a/src/scripts/tidy5e-item.js
+++ b/src/scripts/tidy5e-item.js
@@ -1,6 +1,4 @@
-import ItemSheet5e from "../../../systems/dnd5e/module/item/sheet.js";
-
-export class Tidy5eItemSheet extends ItemSheet5e {
+export class Tidy5eItemSheet extends dnd5e.applications.ItemSheet5e {
   static get defaultOptions() {
     return mergeObject(super.defaultOptions, {
       classes: ["tidy5e", "dnd5ebak", "sheet", "item"],

--- a/src/scripts/tidy5e-npc.js
+++ b/src/scripts/tidy5e-npc.js
@@ -1,5 +1,3 @@
-import ActorSheet5e from "../../../systems/dnd5e/module/actor/sheets/base.js";
-import ActorSheet5eNPC from "../../../systems/dnd5e/module/actor/sheets/npc.js";
 import { preloadTidy5eHandlebarsTemplates } from "./app/tidy5e-npc-templates.js";
 
 import { tidy5eListeners } from "./app/listeners.js";
@@ -23,7 +21,7 @@ Handlebars.registerHelper('check', function(value, comparator) {
   return (value === comparator) ? 'No content' : value;
 });
 
-export default class Tidy5eNPC extends ActorSheet5eNPC {
+export default class Tidy5eNPC extends dnd5e.applications.actor.ActorSheet5eNPC {
 
   /**
    * Define default rendering options for the NPC sheet

--- a/src/scripts/tidy5e-npc.js
+++ b/src/scripts/tidy5e-npc.js
@@ -156,8 +156,8 @@ export default class Tidy5eNPC extends dnd5e.applications.actor.ActorSheet5eNPC 
   /**
    * Add some extra data when rendering the sheet to reduce the amount of logic required within the template.
    */
-  getData(options) {
-    const data = super.getData(options);
+  async getData(options) {
+    const data = await super.getData(options);
     
     Object.keys(data.data.abilities).forEach(id => {
       // let Id = id.charAt(0).toLowerCase() + id.slice(1);

--- a/src/scripts/tidy5e-sheet.js
+++ b/src/scripts/tidy5e-sheet.js
@@ -37,8 +37,8 @@ export class Tidy5eSheet extends dnd5e.applications.actor.ActorSheet5eCharacter 
 	/**
    * Add some extra data when rendering the sheet to reduce the amount of logic required within the template.
    */
-  getData() {
-    const data = super.getData();
+  async getData() {
+    const data = await super.getData();
 
     Object.keys(data.data.abilities).forEach(id => {
     	// let Id = id.charAt(0).toLowerCase() + id.slice(1);

--- a/src/scripts/tidy5e-sheet.js
+++ b/src/scripts/tidy5e-sheet.js
@@ -361,7 +361,7 @@ async function addClassList(app, html, data) {
 				}
 			}
 			classList = "<ul class='class-list'><li class='class-item'>" + classList.join("</li><li class='class-item'>") + "</li></ul>";
-			mergeObject(actor, {"data.flags.tidy5e-sheet.classlist": classList});
+			mergeObject(actor, {"flags.tidy5e-sheet.classlist": classList});
 			let classListTarget = html.find('.bonus-information');
 			classListTarget.append(classList);
 		}

--- a/src/scripts/tidy5e-sheet.js
+++ b/src/scripts/tidy5e-sheet.js
@@ -1,7 +1,3 @@
-import { DND5E } from "../../../systems/dnd5e/module/config.js";
-import ActorSheet5e from "../../../systems/dnd5e/module/actor/sheets/base.js";
-import ActorSheet5eCharacter from "../../../systems/dnd5e/module/actor/sheets/character.js";
-// import { tidy5eSettings } from "./app/settings.js";
 import { Tidy5eUserSettings } from './app/settings.js';
 
 import { preloadTidy5eHandlebarsTemplates } from "./app/tidy5e-templates.js";
@@ -17,7 +13,7 @@ import { tidy5eAmmoSwitch } from "./app/ammo-switch.js";
 let position = 0;
 
 
-export class Tidy5eSheet extends ActorSheet5eCharacter {
+export class Tidy5eSheet extends dnd5e.applications.actor.ActorSheet5eCharacter {
 	
 	get template() {
 		if ( !game.user.isGM && this.actor.limited && !game.settings.get("tidy5e-sheet", "expandedSheetEnabled") ) return "modules/tidy5e-sheet/templates/actors/tidy5e-sheet-ltd.html";

--- a/src/scripts/tidy5e-vehicle.js
+++ b/src/scripts/tidy5e-vehicle.js
@@ -1,13 +1,10 @@
-import ActorSheet5e from "../../../systems/dnd5e/module/actor/sheets/base.js";
-import ActorSheet5eVehicle from "../../../systems/dnd5e/module/actor/sheets/vehicle.js";
-
 import { tidy5eContextMenu } from "./app/context-menu.js";
 import { tidy5eListeners } from "./app/listeners.js";
 import { tidy5eClassicControls } from "./app/classic-controls.js";
 import { tidy5eShowActorArt } from "./app/show-actor-art.js";
 import { tidy5eItemCard } from "./app/itemcard.js";
 
-export class Tidy5eVehicle extends ActorSheet5eVehicle {
+export class Tidy5eVehicle extends dnd5e.applications.actor.ActorSheet5eVehicle {
 
 	static get defaultOptions() {
     let defaultTab = game.settings.get("tidy5e-sheet", "defaultActionsTab") != 'default' ? 'attributes' : 'actions';

--- a/src/scripts/tidy5e-vehicle.js
+++ b/src/scripts/tidy5e-vehicle.js
@@ -34,8 +34,8 @@ export class Tidy5eVehicle extends dnd5e.applications.actor.ActorSheet5eVehicle 
 	/**
    * Add some extra data when rendering the sheet to reduce the amount of logic required within the template.
    */
-  getData() {
-    const data = super.getData();
+  async getData() {
+    const data = await super.getData();
 
     Object.keys(data.data.abilities).forEach(id => {
     	let Id = id.charAt(0).toUpperCase() + id.slice(1);


### PR DESCRIPTION
These changes are sufficient to enable the module to work on v10 and the dnd5e 2.0.0 release as far as I can tell, but they still rely heavily on the compatibility shims. Further updates can remove usage of deprecated code before v11.