### PR TITLE
#594: Update HP values on sheet to type number

### DIFF
--- a/src/templates/actors/tidy5e-npc.html
+++ b/src/templates/actors/tidy5e-npc.html
@@ -55,10 +55,10 @@
 								 	rgba(0,200,0,0.5) calc(100% - ((100% / ({{#if (eq system.attributes.hp.max 0)}} 1 {{else}} {{system.attributes.hp.max}} {{/if}} + {{#if system.attributes.hp.tempmax}}{{system.attributes.hp.tempmax}}{{else}}0{{/if}} )) * ({{system.attributes.hp.value}} + {{#if system.attributes.hp.temp}}{{system.attributes.hp.temp}}{{else}}0{{/if}})) ),
 								 	rgba(0,200,0,0.5) 100%);">
 						</div>
-            <input class="hp-min" name="system.attributes.hp.value" type="text" value="{{system.attributes.hp.value}}"
+            <input class="hp-min" name="system.attributes.hp.value" type="number" step="any" value="{{system.attributes.hp.value}}"
             data-dtype="Number" placeholder="0" maxlength="5">
             <span class="value-seperator">/</span>
-            <input class="hp-max" name="system.attributes.hp.max" type="text" value="{{system.attributes.hp.max}}"
+            <input class="hp-max" name="system.attributes.hp.max" type="number" value="{{system.attributes.hp.max}}"
             data-dtype="Number" placeholder="0" maxlength="5">
           </div>
         </div>
@@ -72,9 +72,9 @@
 
         {{!-- Temp Hit Points --}}
         <div class="portrait-temp">
-          <input name="system.attributes.hp.temp" type="text" class="temphp" placeholder="+{{ localize 'DND5E.Temp' }}" title="+{{ localize 'DND5E.Temp' }}"
+          <input name="system.attributes.hp.temp" type="number" step="any" class="temphp" placeholder="+{{ localize 'DND5E.Temp' }}" title="+{{ localize 'DND5E.Temp' }}"
           value="{{#if (eq system.attributes.hp.temp 0)}}{{else}}{{system.attributes.hp.temp}}{{/if}}" data-dtype="Number" maxlength="5">
-          <input name="system.attributes.hp.tempmax" type="text" class="max-temphp" placeholder="+{{ localize 'DND5E.Max' }}" title="+{{ localize 'DND5E.Max' }}"
+          <input name="system.attributes.hp.tempmax" type="number" class="max-temphp" placeholder="+{{ localize 'DND5E.Max' }}" title="+{{ localize 'DND5E.Max' }}"
           value="{{#if (eq system.attributes.hp.tempmax 0)}}{{else}}{{system.attributes.hp.tempmax}}{{/if}}" data-dtype="Number" maxlength="5">
         </div>
 

--- a/src/templates/actors/tidy5e-sheet.html
+++ b/src/templates/actors/tidy5e-sheet.html
@@ -119,19 +119,19 @@
 								 	rgba(0,200,0,0.5) calc(100% - ((100% / ({{#if (eq system.attributes.hp.max 0)}} 1 {{else}} {{system.attributes.hp.max}} {{/if}} + {{#if system.attributes.hp.tempmax}}{{system.attributes.hp.tempmax}}{{else}}0{{/if}} )) * ({{system.attributes.hp.value}} + {{#if system.attributes.hp.temp}}{{system.attributes.hp.temp}}{{else}}0{{/if}})) ),
 								 	rgba(0,200,0,0.5) 100%);">
 						</div>
-						<input class="hp-min" name="system.attributes.hp.value" type="text" value="{{system.attributes.hp.value}}"
+						<input class="hp-min" name="system.attributes.hp.value" type="number" step="any" value="{{system.attributes.hp.value}}"
 						data-dtype="Number" placeholder="0" maxlength="5">
 						<span class="value-seperator">/</span>
-						<input class="hp-max" name="system.attributes.hp.max" type="text" value="{{system.attributes.hp.max}}"
+						<input class="hp-max" name="system.attributes.hp.max" type="number" value="{{system.attributes.hp.max}}"
 						data-dtype="Number" placeholder="0" maxlength="5">
 					</div>
 				</div>
 
         {{!-- Hit Points --}}
 				<div class="portrait-temp">
-					<input name="system.attributes.hp.temp" type="text" class="temphp" placeholder="+{{ localize 'DND5E.Temp' }}" title="+{{ localize 'DND5E.Temp' }}"
+					<input name="system.attributes.hp.temp" type="number" step="any" class="temphp" placeholder="+{{ localize 'DND5E.Temp' }}" title="+{{ localize 'DND5E.Temp' }}"
 					value="{{system.attributes.hp.temp}}" data-dtype="Number" maxlength="3">
-					<input name="system.attributes.hp.tempmax" type="text" class="max-temphp" placeholder="+{{ localize 'DND5E.Max' }}" title="+{{ localize 'DND5E.Max' }}"
+					<input name="system.attributes.hp.tempmax" type="number" class="max-temphp" placeholder="+{{ localize 'DND5E.Max' }}" title="+{{ localize 'DND5E.Max' }}"
 					value="{{system.attributes.hp.tempmax}}" data-dtype="Number" maxlength="3">
 				</div>
 

--- a/src/templates/actors/tidy5e-vehicle.html
+++ b/src/templates/actors/tidy5e-vehicle.html
@@ -51,19 +51,19 @@
 								 	rgba(0,200,0,0.5) calc(100% - ((100% / ({{#if (eq system.attributes.hp.max 0)}} 1 {{else}} {{system.attributes.hp.max}} {{/if}} + {{#if system.attributes.hp.tempmax}}{{system.attributes.hp.tempmax}}{{else}}0{{/if}} )) * ({{system.attributes.hp.value}} + {{#if system.attributes.hp.temp}}{{system.attributes.hp.temp}}{{else}}0{{/if}})) ),
 								 	rgba(0,200,0,0.5) 100%);">
 						</div>
-            <input class="hp-min" name="system.attributes.hp.value" type="text" value="{{system.attributes.hp.value}}"
+            <input class="hp-min" name="system.attributes.hp.value" type="number" step="any" value="{{system.attributes.hp.value}}"
             data-dtype="Number" placeholder="0" maxlength="5">
             <span class="value-seperator">/</span>
-            <input class="hp-max" name="system.attributes.hp.max" type="text" value="{{system.attributes.hp.max}}"
+            <input class="hp-max" name="system.attributes.hp.max" type="number" value="{{system.attributes.hp.max}}"
             data-dtype="Number" placeholder="0" maxlength="5">
           </div>
         </div>
 
         {{!-- Hit Points --}}
         <div class="portrait-temp">
-          <input name="system.attributes.hp.dt" type="text" class="temphp" placeholder="{{localize 'DND5E.Threshold'}}" title="{{localize 'DND5E.Threshold'}}"
+          <input name="system.attributes.hp.dt" type="number" step="any" class="temphp" placeholder="{{localize 'DND5E.Threshold'}}" title="{{localize 'DND5E.Threshold'}}"
           value="{{system.attributes.hp.dt}}" data-dtype="Number" maxlength="3">
-          <input name="system.attributes.hp.mt" type="text" class="max-temphp" placeholder="{{localize 'DND5E.VehicleMishap'}}" title="{{localize 'DND5E.VehicleMishap'}}"
+          <input name="system.attributes.hp.mt" type="number" class="max-temphp" placeholder="{{localize 'DND5E.VehicleMishap'}}" title="{{localize 'DND5E.VehicleMishap'}}"
           value="{{system.attributes.hp.mt}}" data-dtype="Number" maxlength="3">
         </div>
 


### PR DESCRIPTION
Fixes #594 

Updates the min and max HP input fields to use the "number" input type. This allows for auto-calculation when entering a negative relative value, like "-5".

(Additive values, such as "+6", are not currently supported in v10).

