### PR TITLE
fix checkDeathSaveStatus html find

### DIFF
--- a/src/scripts/tidy5e-sheet.js
+++ b/src/scripts/tidy5e-sheet.js
@@ -300,7 +300,7 @@ async function checkDeathSaveStatus(app, html, data) {
 
     // console.log(`current HP: ${currentHealth}, success: ${deathSaveSuccess}, failure: ${deathSaveFailure}`);
     if (currentHealth <= 0) {
-      $(".tidy5e-sheet .profile").addClass("dead");
+      html.find(".tidy5e-sheet .profile").addClass("dead");
     }
 
     if (


### PR DESCRIPTION
checkDeathSaveStatus is attempting to search the sheet's html using a raw jquery `$` rather than html.find, meaning that it would fail when the rendered html was not in the same window (such as when the character sheet is popped out). 
This fixes the "dead" class not being applied when HP is reduced to zero on a popped-out character sheet window.