### PR TITLE
Fix tool proficiency layout

### DIFF
--- a/src/styles/partials/_main-tab.scss
+++ b/src/styles/partials/_main-tab.scss
@@ -320,6 +320,15 @@
     padding: 0 8px 0 0;
   }
 
+  .proficiency-row h4 {
+    display: inline;
+  }
+
+  .proficiency-row .config-button {
+    margin-left: 0;
+    padding-left: 0;
+  }
+
   label {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
This is a small fix for a layout issue with the tool proficiency section.

With this, that section now looks like this:
![tool-prof](https://github.com/sdenec/tidy5e-sheet/assets/1654763/b929cdd7-afeb-4287-8cf0-0723f4ae815f)

Fixes https://github.com/sdenec/tidy5e-sheet/issues/781. Build and tested locally, tried to keep the CSS as specific as possible so this should not impact anything else.