### PR TITLE
[#797] dnd5e 2.4.0 compatibility updates

### DIFF
--- a/src/module.json
+++ b/src/module.json
@@ -96,8 +96,8 @@
         "id": "dnd5e",
         "manifest": "https://raw.githubusercontent.com/foundryvtt/dnd5e/master/system.json",
         "compatibility": {
-          "minimum": "2.2.1",
-          "verified": "2.2.1"
+          "minimum": "2.4.0",
+          "verified": "2.4.0"
         }
       },
       {

--- a/src/scripts/app/tidy5e-actor-origin-summary-config.js
+++ b/src/scripts/app/tidy5e-actor-origin-summary-config.js
@@ -40,16 +40,17 @@ export default class Tidy5eActorOriginSummaryConfig extends Tidy5eBaseConfigShee
   /** @inheritdoc */
   getData(options) {
     return {
-      race: this.clone.system.details.race,
-      background: this.clone.system.details.background,
+      race: this.clone.system.details.race?.name ?? this.clone.system.details.race,
+      background: this.clone.system.details.background?.name ?? this.clone.system.details.background,
       environment: this.clone.system.details.environment,
       alignment: this.clone.system.details.alignment,
-      source: this.clone.system.details.source,
       dimensions: this.clone.system.traits.dimensions,
 
       isCharacter: this.document.type === "character",
       isNPC: this.document.type === "npc",
       isVehicle: this.document.type === "vehicle",
+      canEditBackground: !this.clone.system.details.background?.name,
+      canEditRace: !this.clone.system.details.race?.name,
     };
   }
 
@@ -68,7 +69,6 @@ export default class Tidy5eActorOriginSummaryConfig extends Tidy5eBaseConfigShee
     const background = foundry.utils.expandObject(formData).background;
     const environment = foundry.utils.expandObject(formData).environment;
     const alignment = foundry.utils.expandObject(formData).alignment;
-    const source = foundry.utils.expandObject(formData).source;
 
     const dimensions = foundry.utils.expandObject(formData).dimensions;
 
@@ -77,35 +77,17 @@ export default class Tidy5eActorOriginSummaryConfig extends Tidy5eBaseConfigShee
     const isVehicle = this.document.type === "vehicle";
 
     if (isCharacter) {
-      // this.clone.updateSource({
-      //   "system.details.race": race,
-      //   "system.details.background": background,
-      //   "system.details.alignment": alignment
-      // });
-
       return this.document.update({
         "system.details.race": race,
         "system.details.background": background,
         "system.details.alignment": alignment,
       });
     } else if (isNPC) {
-      // this.clone.updateSource({
-      //   "system.details.environment": environment,
-      //   "system.details.alignment": alignment,
-      //   "system.details.source": source,
-      // });
-
       return this.document.update({
         "system.details.environment": environment,
         "system.details.alignment": alignment,
-        "system.details.source": source,
       });
     } else if (isVehicle) {
-      // this.clone.updateSource({
-      //   "system.traits.dimensions": dimensions,
-      //   "system.details.source": source,
-      // });
-
       return this.document.update({
         "system.traits.dimensions": dimensions,
       });
@@ -119,27 +101,11 @@ export default class Tidy5eActorOriginSummaryConfig extends Tidy5eBaseConfigShee
   /** @inheritDoc */
   activateListeners(html) {
     super.activateListeners(html);
-    // html.find(".roll-hit-points").click(this._onRollHPFormula.bind(this));
+    for (const override of this._getActorOverrides()) {
+      html.find(`input[name="${override}"],select[name="${override}"]`).each((_, el) => {
+        el.disabled = true;
+        el.dataset.tooltip = "DND5E.ActiveEffectOverrideWarning";
+      });
+    }
   }
-
-  /* -------------------------------------------- */
-
-  // /** @inheritdoc */
-  // async _onChangeInput(event) {
-  //   await super._onChangeInput(event);
-  //   const t = event.currentTarget;
-
-  //   if(t.value === "" || t.value === "0" || t.value === null || t.value === undefined) {
-  //       const rollData = this.object.getRollData();
-  //       // strange patch ...
-  //       this.object.system._source.attributes.hp.max = null;
-  //       this.object._prepareHitPoints(rollData);
-  //       t.value = this.object.system.attributes.hp.max;
-  //   }
-
-  //   // Update clone with new data & re-render
-  //   this.clone.updateSource({ [`system.attributes.${t.name}`]: t.value || null });
-  // }
-
-  /* -------------------------------------------- */
 }

--- a/src/scripts/app/tidy5e-context-menu.js
+++ b/src/scripts/app/tidy5e-context-menu.js
@@ -231,7 +231,7 @@ const _getActiveEffectContextOptions = function (effect) {
   {
     name: "DND5E.ContextMenuActionDuplicate",
     icon: "<i class='fas fa-copy fa-fw'></i>",
-    callback: () => effect.clone({label: game.i18n.format("DOCUMENT.CopyOf", {name: effect.label})}, {save: true})
+    callback: () => effect.clone({label: game.i18n.format("DOCUMENT.CopyOf", {name: effect.name})}, {save: true})
   },
   {
     name: "DND5E.ContextMenuActionDelete",
@@ -261,7 +261,7 @@ const _getActiveEffectContextOptions = function (effect) {
       name: "DND5E.ContextMenuActionDuplicate",
       icon: "<i class='fas fa-copy fa-fw'></i>",
       callback: () =>
-        effect.clone({ label: game.i18n.format("DOCUMENT.CopyOf", { name: effect.label }) }, { save: true }),
+        effect.clone({ label: game.i18n.format("DOCUMENT.CopyOf", { name: effect.name }) }, { save: true }),
     });
     options.push({
       name: "DND5E.ContextMenuActionDelete",

--- a/src/scripts/app/tidy5e-exhaustion.js
+++ b/src/scripts/app/tidy5e-exhaustion.js
@@ -301,7 +301,7 @@ export function Tidy5eExhaustionCreateActiveEffect(effect, data, id) {
     game.settings.get(CONSTANTS.MODULE_ID, "exhaustionEffectsEnabled") == "cub"
   ) {
     let actor = game.actors.get(effect.parent._id);
-    let effectName = effect.label;
+    let effectName = effect.name;
     if (effectName.includes(game.settings.get(CONSTANTS.MODULE_ID, "exhaustionEffectCustom"))) {
       debug("tidy5e-exhaustion | createActiveEffect | effectName = " + effectName);
       if (actor.type === "character") {
@@ -333,7 +333,7 @@ export function Tidy5eExhaustionDeleteActiveEffect(effect, data, id) {
     const actor = game.actors.get(effect.parent._id);
     const effectName = game.settings.get(CONSTANTS.MODULE_ID, "exhaustionEffectCustom");
     const levels = game.settings.get(CONSTANTS.MODULE_ID, "exhaustionEffectCustomTiers");
-    const effectLabel = effect.label;
+    const effectLabel = effect.name;
     if (effectLabel.includes(effectName)) {
       const tokens = canvas.tokens.placeables;
       const index = tokens.findIndex((x) => x.actor._id === effect.parent._id);

--- a/src/scripts/tidy5e-item.js
+++ b/src/scripts/tidy5e-item.js
@@ -20,12 +20,6 @@ export class Tidy5eItemSheet extends dnd5e.applications.item.ItemSheet5e {
   }
 }
 
-async function addEditorHeadline(app, html, data) {
-  html
-    .find(".tab[data-tab=description] .editor")
-    .prepend(`<h2 class="details-headline">${game.i18n.localize("TIDY5E.ItemDetailsHeadline")}</h2>`);
-}
-
 /* -------------------------------------------- */
 
 export function Tidy5eSheetItemInitialize() {
@@ -34,7 +28,6 @@ export function Tidy5eSheetItemInitialize() {
 }
 
 Hooks.on("renderTidy5eItemSheet", (app, html, data) => {
-  addEditorHeadline(app, html, data);
   applySpellClassFilterItemSheet(app, html, data);
 
   // NOTE LOCKS ARE THE LAST THING TO SET

--- a/src/styles/_items.scss
+++ b/src/styles/_items.scss
@@ -169,11 +169,33 @@
         border-left: 1px solid var(--t5e-faint-color);
         line-height: 20px;
         font-weight: 600;
+        display: flex;
+        justify-content: space-between;
+        gap: 0.25em;
 
         input {
           height: 20px;
           background: transparent;
           font-weight: 400;
+        }
+
+        span {
+          padding-inline: 4px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          font-weight: 400;
+        }
+
+        .config-button {
+          display: none;
+          font-size: var(--font-size-14);
+          font-weight: normal;
+          padding-inline-end: 0.25em;
+        }
+
+        &:hover .config-button {
+          display: block;
         }
 
         select {

--- a/src/styles/_items.scss
+++ b/src/styles/_items.scss
@@ -770,6 +770,67 @@
       }
     }
   }
+
+  [data-tab="description"] {
+    align-content: stretch;
+
+    .item-description {
+      .description-header {
+        display: flex;
+        align-items: first baseline;
+        gap: 0.5em;
+        margin-block-end: 0;
+        padding: 0.25rem;
+        background-color: rgba(0, 0, 0, 0.05);
+
+        .description-edit {
+          margin-inline-start: auto;
+          opacity: 20%;
+
+          .fa-solid.fa-edit {
+            position: absolute;
+            inset-block: 0;
+            inset-inline-end: 0;
+            padding: 6px;
+          }
+        }
+
+        &:hover .description-edit {
+          opacity: 100%;
+        }
+      }
+
+      .editor + .description-header {
+        margin-block-start: 0.5rem;
+      }
+
+      .editor:not(.prosemirror) {
+        height: auto;
+        padding-inline: 0.25rem;
+      }
+
+      .accordion {
+        margin-block-end: 0.5rem;
+
+        p:last-child {
+          margin-block-end: 0;
+        }
+        &.collapsed > .editor.accordion-content {
+          height: 0;
+        }
+      }
+
+      .editor.accordion-content > .editor-content {
+        overflow: hidden;
+      }
+
+      .accordion-indicator {
+        align-self: center;
+        opacity: 0.5;
+        font-size: 0.75em;
+      }
+    }
+  }
 }
 
 // actor flags

--- a/src/styles/partials/_character-details.scss
+++ b/src/styles/partials/_character-details.scss
@@ -166,6 +166,10 @@
   // position: relative;
   z-index: 100;
 
+  .creature-type .config-button:hover {
+    color: var(--t5e-primary-accent);
+  }
+
   li {
     flex: 1;
     margin-right: 0.5rem;

--- a/src/templates/actors/parts/tidy5e-effects.html
+++ b/src/templates/actors/parts/tidy5e-effects.html
@@ -17,13 +17,13 @@
 			<li class="item effect" data-effect-id="{{effect.id}}" data-effectId="{{effect.id}}">
 				<div class="item-name effect-name">
 					<img class="item-image" src="{{effect.icon}}" />
-					<h4>{{effect.label}}</h4>
+					<h4>{{effect.name}}</h4>
 				</div>
 				<div class="item-detail effect-source" title="{{effect.sourceName}}">
 					<span>{{effect.sourceName}}</span>
 				</div>
 				<div class="item-detail effect-duration">{{effect.duration.label}}</div>
-				{{#if @root.owner}} 
+				{{#if @root.owner}}
 				<div class="item-controls effect-controls flexrow" {{#if @root.classicControlsDisabled}} style="display:none" {{/if}}>
 					{{#if @root.editable}}
 					<a class="effect-control" data-action="toggle" title="{{#if effect.disabled}}{{localize 'DND5E.EffectEnable'}}{{else}}{{localize 'DND5E.EffectDisable'}}{{/if}}">

--- a/src/templates/actors/parts/tidy5e-features.html
+++ b/src/templates/actors/parts/tidy5e-features.html
@@ -86,7 +86,7 @@
           <i class="fas fa-bolt" title="{{localize 'DND5E.Charged'}}"></i>
 
           {{else if ctx.hasUses}}
-          <input class="uses-value" name="system.uses.value" type="text" value="{{item.system.uses.value}}"> / 
+          <input class="uses-value" name="system.uses.value" type="text" value="{{item.system.uses.value}}"> /
           <input class="uses-max" name="system.uses.max" type="text" value="{{item.system.uses.max}}">
           {{else unless @root.isNPC}}
           <a class="addCharges" value="Add">Add</a>
@@ -98,11 +98,11 @@
           {{item.labels.activation}}
           {{/if}}
         </div>
-        
+
         {{#unless @root.isVehicle}}
         {{#if @root.isCharacter}}
         <div class="item-detail item-source">
-          <span class="truncate" title="{{item.system.source}}">{{item.system.source}}</span>
+          <span class="truncate" title="{{item.system.source.label}}">{{item.system.source.label}}</span>
         </div>
         <div class="item-detail item-requirements">
           <span class="truncate" title="{{item.system.requirements}}">{{item.system.requirements}}</span>
@@ -141,7 +141,7 @@
         {{else}}
           {{#if @root.isCharacter}}
           <div class="item-detail item-source">
-            <span class="truncate" title="{{item.system.source}}">{{item.system.source}}</span>
+            <span class="truncate" title="{{item.system.source.label}}">{{item.system.source.label}}</span>
           </div>
           <div class="item-detail item-requirements">
             <span class="truncate" title="{{item.system.requirements}}">{{item.system.requirements}}</span>
@@ -166,9 +166,9 @@
         {{#if @root.owner}}
         <div class="item-controls flexrow" {{#if @root.classicControlsDisabled}} style="display:none" {{/if}}>
           {{#if ctx.attunement}}
-            <a class="item-control item-attunement 
+            <a class="item-control item-attunement
               {{#if (eq item.system.attunement 2) }}active{{/if}} {{item.attunement.cls}}" title="{{localize item.attunement.title}}">
-              <i class="fas fa-sun"></i> 
+              <i class="fas fa-sun"></i>
               <span class="control-label">
                 {{#if (eq item.system.attunement 2) }}
                   {{localize "TIDY5E.Deattune"}}
@@ -182,10 +182,10 @@
 
           <a class="item-control item-toggle {{ctx.toggleClass}}" title="{{ctx.toggleTitle}}">
             {{#if (eq ctx.toggleClass 'active')}}
-              <i class="fas fa-user-alt"></i> 
+              <i class="fas fa-user-alt"></i>
               <span class="control-label">{{localize "TIDY5E.Unequip"}}</span>
             {{else}}
-              <i class="fas fa-user-alt inactive"></i> 
+              <i class="fas fa-user-alt inactive"></i>
               <span class="control-label">{{localize "TIDY5E.Equip"}}</span>
             {{/if}}
           </a>

--- a/src/templates/actors/parts/tidy5e-origin-summary-config.html
+++ b/src/templates/actors/parts/tidy5e-origin-summary-config.html
@@ -1,55 +1,66 @@
 <form>
-    {{#if isCharacter}}
-
-        <div class="form-group">
-            <label>{{localize "DND5E.Race"}}</label>
-            <textarea rows="4" cols="50" name="race" value="{{race}}"
-                placeholder="{{ localize 'DND5E.Race' }}">{{race}}</textarea>
-        </div>
-        <div class="form-group">
-            <label>{{localize "DND5E.Background"}}</label>
-            <textarea rows="4" cols="50" name="background" value="{{background}}"
-                placeholder="{{ localize 'DND5E.Background' }}">{{background}}</textarea>
-        </div>
-        <div class="form-group">
-            <label>{{localize "DND5E.Alignment"}}</label>
-            <textarea rows="4" cols="50" name="alignment" value="{{alignment}}"
-                placeholder="{{ localize 'DND5E.Alignment' }}">{{alignment}}</textarea>
-        </div>
-
-    {{else if isNPC}}
-
-        <div class="environment form-group">
-            <label>{{localize "TIDY5E.Environment"}}</label>
-            <textarea rows="4" cols="50" name="environment" value="{{environment}}"
-                placeholder="{{ localize 'TIDY5E.Environment' }}">{{environment}}</textarea>
-        </div>
-        <div class="form-group">
-            <label>{{localize "DND5E.Alignment"}}</label>
-            <textarea rows="4" cols="50" name="alignment" value="{{alignment}}"
-                placeholder="{{ localize 'DND5E.Alignment' }}">{{alignment}}</textarea>
-        </div>
-        <div class="form-group">
-            <label>{{localize "DND5E.Source"}}</label>
-            <textarea rows="4" cols="50" name="source" value="{{source}}"
-                placeholder="{{ localize 'DND5E.Source' }}">{{source}}</textarea>
-        </div>
-
-    {{else if isVehicle}}
-
-        <div class="form-group">
-            <label>{{localize "DND5E.Dimensions"}}</label>
-            <textarea rows="4" cols="50" name="dimensions" value="{{dimensions}}"
-                placeholder="{{ localize 'DND5E.Dimensions' }}">{{dimensions}}</textarea>
-        </div>
-
+  {{#if isCharacter}}
+  <div class="form-group">
+    <label>{{localize 'DND5E.Race'}}</label>
+    {{#if canEditRace}}
+    <textarea rows="4" cols="50" name="race" value="{{race}}" placeholder='{{localize "DND5E.Race"}}'>
+{{race}}</textarea
+    >
     {{else}}
-
-      <!-- TODO SOMETHING ? -->
-
+    <span>{{race}}</span>
     {{/if}}
+  </div>
+  <div class="form-group">
+    <label>{{localize 'DND5E.Background'}}</label>
+    {{#if canEditBackground}}
+    <textarea rows="4" cols="50" name="background" value="{{background}}" placeholder='{{localize "DND5E.Background"}}'>
+{{background}}</textarea
+    >
+    {{else}}
+    <span>{{background}}</span>
+    {{/if}}
+  </div>
+  <div class="form-group">
+    <label>{{localize 'DND5E.Alignment'}}</label>
+    <textarea rows="4" cols="50" name="alignment" value="{{alignment}}" placeholder='{{localize "DND5E.Alignment"}}'>
+{{alignment}}</textarea
+    >
+  </div>
 
-    <button type="submit">
-      <i class="far fa-save"></i> {{localize "Save"}}
-    </button>
+  {{else if isNPC}}
+
+  <div class="environment form-group">
+    <label>{{localize 'TIDY5E.Environment'}}</label>
+    <textarea
+      rows="4"
+      cols="50"
+      name="environment"
+      value="{{environment}}"
+      placeholder='{{localize "TIDY5E.Environment"}}'
+    >
+{{environment}}</textarea
+    >
+  </div>
+  <div class="form-group">
+    <label>{{localize 'DND5E.Alignment'}}</label>
+    <textarea rows="4" cols="50" name="alignment" value="{{alignment}}" placeholder='{{localize "DND5E.Alignment"}}'>
+{{alignment}}</textarea
+    >
+  </div>
+
+  {{else if isVehicle}}
+
+  <div class="form-group">
+    <label>{{localize 'DND5E.Dimensions'}}</label>
+    <textarea rows="4" cols="50" name="dimensions" value="{{dimensions}}" placeholder='{{localize "DND5E.Dimensions"}}'>
+{{dimensions}}</textarea
+    >
+  </div>
+
+  {{/if}}
+
+  <button type="submit">
+    <i class="far fa-save"></i>
+    {{localize 'Save'}}
+  </button>
 </form>

--- a/src/templates/actors/tidy5e-npc.html
+++ b/src/templates/actors/tidy5e-npc.html
@@ -179,7 +179,7 @@
                 </span>
             </span>
             <span class="origin-summary-text" data-tooltip="{{system.details.alignment}}" data-placeholder="{{ localize 'DND5E.Alignment' }}"><h4>{{system.details.alignment}}</h4></span>
-            <span class="origin-summary-text source source-info" data-tooltip="{{system.details.source}}" data-placeholder="{{ localize 'DND5E.Source' }}"><h4>{{system.details.source}}</h4></span>
+            <span class="origin-summary-text source source-info" data-tooltip="{{system.details.source.label}}" data-placeholder="{{ localize 'DND5E.Source' }}"><h4>{{system.details.source.label}}</h4></span>
           </li>
           <li class="proficiency">
             {{ localize 'DND5E.Proficiency' }}: {{numberFormat system.attributes.prof decimals=0 sign=true}}

--- a/src/templates/actors/tidy5e-sheet.html
+++ b/src/templates/actors/tidy5e-sheet.html
@@ -198,7 +198,18 @@
 								</ul>
 							</li>
 						</ul>
+                        <span class="creature-type" title="{{labels.type}}">
+                        {{#if (and system.details.race.id owner)}}
+                            <a class="config-button" data-action="type" title="{{localize 'DND5E.CreatureTypeConfig'}}">
+                                {{labels.type}}
+                            </a>
+                        {{else}}
+                            {{labels.type}}
+                        {{/if}}
+                        </span>
+                        {{#if system.details.race}}
                         <span class="origin-summary-text" data-tooltip="{{system.details.race}}" data-placeholder="{{ localize 'DND5E.Race' }}"><h4>{{system.details.race}}</h4></span>
+                        {{/if}}
 						<span class="origin-summary-text" data-tooltip="{{system.details.background}}" data-placeholder="{{ localize 'DND5E.Background' }}"><h4>{{#if labels.background}}{{labels.background}}{{else}}{{system.details.background}}{{/if}}</h4></span>
 						<span class="origin-summary-text" data-tooltip="{{system.details.alignment}}" data-placeholder="{{ localize 'DND5E.Alignment' }}"><h4>{{system.details.alignment}}</h4></span>
 					</li>


### PR DESCRIPTION
#797

Makes numerous adjustments for dnd5e compatibility.

1. Fixed item accordion styles
2. Fixed item source styles
3. Made Race and Background read-only in the Origin Summary dialog when their respective item is present in the Features tab
4. Added creature type to Player Character sheet
5. Resolved deprecation warnings as discovered
6. Updated min system compatibility to 2.4.0 since there are breaking changes in the 2.4 update